### PR TITLE
Deleted roles would never get up to date causing empty categories

### DIFF
--- a/src/UCommerce.Sitecore/Security/SitecoreUserGroupService.cs
+++ b/src/UCommerce.Sitecore/Security/SitecoreUserGroupService.cs
@@ -51,9 +51,15 @@ namespace UCommerce.Sitecore.Security
 			{
 				var roleNamesNotCreatedAsUserGroups = sitecoreDomainRoles.Where(x => existingUserGroups.All(y => y.ExternalId != x.LocalName)).Select(x => x.LocalName).ToList();
 
+				var roleNamesThatHasBeenDeletedInSitecore = existingUserGroups
+					.Where(x => sitecoreDomainRoles.All(y => y.LocalName != x.ExternalId)).ToList();
+				
 				var newGroups = MapExternalUserGroupsToInternalUserGroups(roleNamesNotCreatedAsUserGroups);
 
-				ObjectFactory.Instance.Resolve<IRepository<UserGroup>>().Save(newGroups);
+				var repository = ObjectFactory.Instance.Resolve<IRepository<UserGroup>>();
+				
+				repository.Delete(roleNamesThatHasBeenDeletedInSitecore);
+				repository.Save(newGroups);
 
 				var allGroups = existingUserGroups.Concat(newGroups).ToList();
 


### PR DESCRIPTION
This is quite a wiered bug due to NHibernate UOW. If roles in sitecore and Ucommerce are not aligned we would flush the entity graph on each request, causing new categories created in the old UI to have empty duplicated categories. This is due to the way our old UIs are structured where Entities are surfaced and newed up by the UI, making them part of the object graph, thus being flushed along with the roles being saved. 