### PR TITLE
Feature/10212 children count for content

### DIFF
--- a/src/Ucommerce.Sitecore/Content/SitecoreContentNodeConverter.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreContentNodeConverter.cs
@@ -28,6 +28,7 @@ namespace Ucommerce.Sitecore.Content
 				NodeType = node.NodeType,
 				Icon = "/~/icon/" + item.Appearance.Icon,
 				HasChildren = item.HasChildren,
+				ChildrenCount = item.Children.Count,
 				AutoLoad = node.AutoLoad,
 				DimNode = false,
 				Url = _contentService.GetContent(item.ID.Guid.ToString()).Url

--- a/src/Ucommerce.Sitecore/Content/SitecoreContentTreeService.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreContentTreeService.cs
@@ -26,7 +26,10 @@ namespace Ucommerce.Sitecore.Content
 			var item = _sitecoreContext.DatabaseForContent.GetItem(ID.Parse(id));
 			var children = new List<ITreeNodeContent>();
 
-			item.Children.ToList().ForEach(x => children.Add(new TreeNodeContent("content", x.ID.ToString())));
+			item.Children.ToList().ForEach(x => children.Add(new TreeNodeContent("content", x.ID.ToString())
+			{
+				ChildrenCount = x.Children.Count
+			}));
 
 			return children;
 		}

--- a/src/Ucommerce.Sitecore/Content/SitecoreImageNodeConverter.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreImageNodeConverter.cs
@@ -35,10 +35,10 @@ namespace Ucommerce.Sitecore.Content
 				NodeType = nodeType,
 				Icon = "/~/icon/" + item.Appearance.Icon,
 				HasChildren = item.HasChildren,
+				ChildrenCount = item.Children.Count,
 				AutoLoad = autoload,
 				DimNode = false,
-				Url = mediaitem.MediaData.HasContent ? _imageService.GetImage(item.ID.ToString()).Url : "",
-				ChildrenCount = item.Children.Count
+				Url = mediaitem.MediaData.HasContent ? _imageService.GetImage(item.ID.ToString()).Url : ""
 			};
 		}
 	}

--- a/src/Ucommerce.Sitecore/Content/SitecoreImageTreeService.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreImageTreeService.cs
@@ -43,7 +43,6 @@ namespace Ucommerce.Sitecore.Content
         {
             string nodeType = string.Empty;
             nodeType = item.Template.Key == "media folder" ? "Folder" : "Image";
-			var mediaitem = MediaManager.GetMedia(item);
 			return new TreeNodeContent(nodeType, item.ID.ToString())
 			{
 				ChildrenCount = item.Children.Count


### PR DESCRIPTION
`NodeItem` property `ChildrenCount` (on `content`) was always 0.
This is now fixed to represent correct number, just like in case of `image`s.

