### PR TITLE
fix: new categories generate image not found rather than empty image

### DIFF
--- a/src/Ucommerce.Sitecore/Content/SitecoreImageService.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreImageService.cs
@@ -10,97 +10,105 @@ using Ucommerce.Web;
 
 namespace Ucommerce.Sitecore.Content
 {
-	public class SitecoreImageService : IImageService
-	{
-		private readonly ILoggingService _loggingService;
-		private readonly ISitecoreContext _sitecoreContext;
+    public class SitecoreImageService : IImageService
+    {
+        private readonly ILoggingService _loggingService;
+        private readonly ISitecoreContext _sitecoreContext;
 
-		[Mandatory] public IAbsoluteUrlService AbsoluteUrlService { get; set; }
+        [Mandatory] public IAbsoluteUrlService AbsoluteUrlService { get; set; }
 
-		public SitecoreImageService(ILoggingService loggingService, ISitecoreContext sitecoreContext)
-		{
-			_loggingService = loggingService;
-			_sitecoreContext = sitecoreContext;
-		}
+        public SitecoreImageService(ILoggingService loggingService, ISitecoreContext sitecoreContext)
+        {
+            _loggingService = loggingService;
+            _sitecoreContext = sitecoreContext;
+        }
 
-		/// <summary>
-		/// Resolves an imageUrl from an id.
-		/// </summary>
-		/// <param name="contentId">Id of a sitecore item.</param>
-		/// <returns>Link to an .ashx which resolves to an image.</returns>
-		/// <remarks>Url must be absolute and return an .ashx page which is the way that SiteCore stores and resolves images.</remarks>
-		public virtual Ucommerce.Content.Content GetImage(string contentId)
-		{
-			var content = new Ucommerce.Content.Content
-				{
-					Id = contentId,
-					Name = "image-not-found.png",
-					Url = AbsoluteUrlService.GetAbsoluteUrl("sitecore modules/Shell/Ucommerce/images/ui/image-not-found.png"),
-					NodeType = Constants.ImagePicker.Image
-				};
+        /// <summary>
+        /// Resolves an imageUrl from an id.
+        /// </summary>
+        /// <param name="contentId">Id of a sitecore item.</param>
+        /// <returns>Link to an .ashx which resolves to an image.</returns>
+        /// <remarks>Url must be absolute and return an .ashx page which is the way that SiteCore stores and resolves images.</remarks>
+        public virtual Ucommerce.Content.Content GetImage(string contentId)
+        {
+            var content = new Ucommerce.Content.Content();
+            if (string.IsNullOrEmpty(contentId))
+            {
+                return content;
+            }
 
-			if (string.IsNullOrEmpty(contentId))
-				return content;
+            var item = GetItemFromId(contentId);
 
-			var item = GetItemFromId(contentId);
+            if (item == null)
+            {
+                _loggingService.Log<SitecoreContentService>(
+                    string.Format("Item with id: {0} was not found. Check that content exists in database", contentId));
+                return ImageNotFound(contentId);
+            }
 
-			if (item == null)
-			{
-				_loggingService.Log<SitecoreContentService>(string.Format("Item with id: {0} was not found. Check that content exists in database", contentId));
-				return content;
-			}
+            return MapItemToContent(item);
+        }
 
-			return MapItemToContent(item);
-		}
+        protected virtual Ucommerce.Content.Content MapItemToContent(Item item)
+        {
+            return new Ucommerce.Content.Content()
+            {
+                Name = item.Name,
+                Icon = item.Appearance.Icon,
+                Url = GetMediaUrl(item),
+                Id = item.ID.ToString(),
+                NodeType = GetNodeType(item)
+            };
+        }
 
-		protected virtual Ucommerce.Content.Content MapItemToContent(Item item)
-		{
-			return new Ucommerce.Content.Content()
-			{
-				Name = item.Name,
-				Icon = item.Appearance.Icon,
-				Url = GetMediaUrl(item),
-				Id = item.ID.ToString(),
-				NodeType = GetNodeType(item)
-			};
-		}
+        protected virtual string GetNodeType(Item item)
+        {
+            var folderTemplateKeys = new[] {"media folder", "node"};
+            var imageTemplateKey = "image";
 
-		protected virtual string GetNodeType(Item item)
-		{
-			var folderTemplateKeys = new[] {"media folder", "node"};
-			var imageTemplateKey = "image";
+            if (folderTemplateKeys.Contains(item.Template.Key))
+            {
+                return Constants.ImagePicker.Folder;
+            }
 
-			if (folderTemplateKeys.Contains(item.Template.Key))
-			{
-				return Constants.ImagePicker.Folder;
-			}
+            if (item.Template.Key == imageTemplateKey ||
+                item.Template.BaseTemplates.Any(x => x.Key == imageTemplateKey))
+            {
+                return Constants.ImagePicker.Image;
+            }
 
-			if (item.Template.Key == imageTemplateKey ||
-			    item.Template.BaseTemplates.Any(x => x.Key == imageTemplateKey))
-			{
-				return Constants.ImagePicker.Image;
-			}
+            return Constants.ImagePicker.File;
+        }
 
-			return Constants.ImagePicker.File;
-		}
+        /// <summary>
+        /// Returns a sitecore item based on id.
+        /// </summary>
+        /// <param name="id">id of the sitecore item.</param>
+        /// <returns>Sitecore item</returns>
+        /// <remarks>
+        /// Runs on Context object, initialized on each Http request, using configured
+        /// database from the site detected by SiteCore, which is configured in web.config under sites node.
+        /// </remarks>
+        protected virtual Item GetItemFromId(string id)
+        {
+            return _sitecoreContext.DatabaseForContent.GetItem(id);
+        }
 
-		/// <summary>
-		/// Returns a sitecore item based on id.
-		/// </summary>
-		/// <param name="id">id of the sitecore item.</param>
-		/// <returns>Sitecore item</returns>
-		/// <remarks>
-		/// Runs on Context object, initialized on each Http request, using configured
-		/// database from the site detected by SiteCore, which is configured in web.config under sites node.
-		/// </remarks>
-		protected virtual Item GetItemFromId(string id)
-		{
-			return _sitecoreContext.DatabaseForContent.GetItem(id);
-		}
+        protected virtual string GetMediaUrl(Item item)
+        {
+            return MediaManager.GetMediaUrl(item, new MediaUrlOptions {AlwaysIncludeServerUrl = true});
+        }
 
-		protected virtual string GetMediaUrl(Item item)
-		{
-			return MediaManager.GetMediaUrl(item, new MediaUrlOptions { AlwaysIncludeServerUrl = true });
-		}
-	}
+        private Ucommerce.Content.Content ImageNotFound(string id)
+        {
+            return new Ucommerce.Content.Content
+            {
+                Id = id,
+                Name = "image-not-found.png",
+                Url = AbsoluteUrlService.GetAbsoluteUrl(
+                    "sitecore modules/Shell/Ucommerce/images/ui/image-not-found.png"),
+                NodeType = Constants.ImagePicker.Image
+            };
+        }
+    }
 }


### PR DESCRIPTION
### New categories created with image-not-found pre-selected value in media section

- This has surfaced after updates in image/content pickers
