### PR TITLE
fix: use only relative urls in sitecore 

### DIFF
--- a/src/Ucommerce.Sitecore/Content/SitecoreContentService.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreContentService.cs
@@ -45,7 +45,7 @@ namespace Ucommerce.Sitecore.Content
 
 		    var urlOptions = new Links.UrlOptions()
 		    {
-		        AlwaysIncludeServerUrl = true,
+		        AlwaysIncludeServerUrl = false,
                 Language = Context.Language,
                 Site = SiteContext.Current
 		    };

--- a/src/Ucommerce.Sitecore/Content/SitecoreImageService.cs
+++ b/src/Ucommerce.Sitecore/Content/SitecoreImageService.cs
@@ -16,8 +16,6 @@ namespace Ucommerce.Sitecore.Content
         private readonly ILoggingService _loggingService;
         private readonly ISitecoreContext _sitecoreContext;
 
-        [Mandatory] public IAbsoluteUrlService AbsoluteUrlService { get; set; }
-
         public SitecoreImageService(ILoggingService loggingService, ISitecoreContext sitecoreContext)
         {
             _loggingService = loggingService;
@@ -29,7 +27,6 @@ namespace Ucommerce.Sitecore.Content
         /// </summary>
         /// <param name="contentId">Id of a sitecore item.</param>
         /// <returns>Link to an .ashx which resolves to an image.</returns>
-        /// <remarks>Url must be absolute and return an .ashx page which is the way that SiteCore stores and resolves images.</remarks>
         public virtual Ucommerce.Content.Content GetImage(string contentId)
         {
             var content = new Ucommerce.Content.Content();
@@ -97,7 +94,7 @@ namespace Ucommerce.Sitecore.Content
 
         protected virtual string GetMediaUrl(Item item)
         {
-            return MediaManager.GetMediaUrl(item, new MediaUrlOptions {AlwaysIncludeServerUrl = true});
+            return MediaManager.GetMediaUrl(item, new MediaUrlOptions {AlwaysIncludeServerUrl = false});
         }
 
         private Ucommerce.Content.Content ImageNotFound(string id)
@@ -106,8 +103,7 @@ namespace Ucommerce.Sitecore.Content
             {
                 Id = id,
                 Name = "image-not-found.png",
-                Url = VirtualPathUtility.ToAbsolute(
-                    "~/sitecore modules/Shell/Ucommerce/images/ui/image-not-found.png"),
+                Url = "/sitecore modules/Shell/Ucommerce/images/ui/image-not-found.png",
                 NodeType = Constants.ImagePicker.Image
             };
         }

--- a/src/Ucommerce.Sitecore93/Content/SitecoreImageService.cs
+++ b/src/Ucommerce.Sitecore93/Content/SitecoreImageService.cs
@@ -10,7 +10,7 @@ namespace Ucommerce.Sitecore93.Content
     	{
 	        protected override string GetMediaUrl(Item item)
             {
-	            return MediaManager.GetMediaUrl(item, new MediaUrlBuilderOptions { AlwaysIncludeServerUrl = true });
+	            return MediaManager.GetMediaUrl(item, new MediaUrlBuilderOptions { AlwaysIncludeServerUrl = false });
             }
 
 	        public SitecoreImageService(ILoggingService loggingService, ISitecoreContext sitecoreContext) : base(loggingService, sitecoreContext)


### PR DESCRIPTION
because absolute urls do not work without a site context.

How to test:

Install Avenue.

Run the scratchindexer multiple times and examine the indexes. There should be both a complete A and B folder with 5 indexes. 
Browse the catalog in Avenue. No YSODs should appear.
Use the Catalogs and Products apps in Ucommerce and browse. Make sure that the Tops category displays the "Image not found" image.
