### PR TITLE
Add outputDir option to build scripts

### DIFF
--- a/tools/Deploy/Deploy.To.Package.ps1
+++ b/tools/Deploy/Deploy.To.Package.ps1
@@ -7,7 +7,10 @@ Param(
 
     [Parameter(Mandatory=$False)]
     [ValidateSet("Debug", "Release")]
-    [string]$Configuration = "Debug"
+    [string]$Configuration = "Debug",
+        
+    [Parameter(Mandatory=$False)]
+    [string]$outputDir = "c:\tmp"
 )
 
 function Get-ScriptDirectory {
@@ -23,12 +26,20 @@ function Run-It () {
 
         Import-Module "$scriptPath\..\psake\4.9.0\psake.psm1"
 
+        If(!(test-path $outputDir))
+        {
+            New-Item -ItemType Directory -Force -Path $outputDir
+        }
+        $outputDirPathInfo = Resolve-Path $outputDir
+        $outputDir = $outputDirPathInfo.Path
+
         $properties = @{
                 "configuration"="$Configuration";
                 "UpdateAssemblyInfo"="$UpdateAssemblyInfo";
                 "version"="$Version";
                 "base_dir"="$base_dir";
                 "src"=$src;
+                "zipDestinationFolder"=$outputDir;
                 "working_dir"="$env:TEMP\uCommerceTmp\8e0acd5c-f842-49db-933d-cc9e61fcff53";
             };
 

--- a/tools/Deploy/uCommerce.build.ps1
+++ b/tools/Deploy/uCommerce.build.ps1
@@ -4,7 +4,7 @@ properties {
     $configuration = 'Debug'
     $src = "."
     $zipFileName = "Ucommerce-for-Sitecore-{1}.zip"
-    $zipDestinationFolder = "C:\tmp"
+    $zipDestinationFolder = $null
     $solution_file = "Ucommerce.Sitecore.sln"
     $working_dir = $null
     $version = $null


### PR DESCRIPTION
Eliminating the reliance on c:\tmp being available (it's not available on Github Actions runners).

If the argument is omitted, the default is still c:/tmp, so current CI should run the same as before.

So this is preparation for a leaner CI system.

Sister PR: https://github.com/Ucommercenet/Ucommerce/pull/539