### PR TITLE
fix: Creating or updating a ProductCatalogGroup would throw an exception

### DIFF
--- a/src/Ucommerce.Sitecore/SitecoreDataProvider/Impl/TemplateBuilders/BaseTemplates/BaseProductCatalogGroupTemplate.cs
+++ b/src/Ucommerce.Sitecore/SitecoreDataProvider/Impl/TemplateBuilders/BaseTemplates/BaseProductCatalogGroupTemplate.cs
@@ -60,12 +60,22 @@ namespace Ucommerce.Sitecore.SitecoreDataProvider.Impl.TemplateBuilders.BaseTemp
 			list.SafeAdd(FieldIds.Store.DescriptionFieldId, store.Description);
 			list.SafeAdd(FieldIds.Store.CurrencyFieldId, store.Currency.SitecoreId().ToString());
 			list.SafeAdd(FieldIds.Store.EmailProfileFieldId, store.EmailProfile.SitecoreId().ToString());
-			list.SafeAdd(FieldIds.Store.OrderNumberSeriesFieldId, store.OrderNumberSerie.SitecoreId().ToString());
+			list.SafeAdd(FieldIds.Store.OrderNumberSeriesFieldId, ConvertOrderNumberSeriesIdToSitecoreId(store.OrderNumberSerie));
 			list.SafeAdd(FieldIds.Store.ProductReviewRequiresApprovalFieldId, store.ProductReviewsRequireApproval.ToSitecoreFormat());
 			list.SafeAdd(FieldIds.Store.CreateCustomersAsMembersFieldId, store.CreateCustomersAsMembers.ToSitecoreFormat());
 			list.SafeAdd(FieldIds.Store.MemberGroupFieldId, ConvertMemberGroupIdToSitecoreId(store.MemberGroupId));
 			list.SafeAdd(FieldIds.Store.MemberTypeFieldId, ConvertMemberTypeIdToSitecoreId(store.MemberTypeId));
 			list.SafeAdd(FieldIDs.Revision, store.Guid.Derived(store.ModifiedOn).ToString());
+		}
+
+		private string ConvertOrderNumberSeriesIdToSitecoreId(OrderNumberSerie storeOrderNumberSerie)
+		{
+			if (storeOrderNumberSerie == null)
+			{
+				return string.Empty;
+			}
+
+			return storeOrderNumberSerie.SitecoreId().ToString();
 		}
 
 		private string GetSecurityPermisionsFor(ProductCatalogGroup store)


### PR DESCRIPTION
The dataprovider required an associated OrderNumberSerie - even though the property is nullable in the rest of the system. This came to light now with the implementation of the new Stores UI. The data provider is now aligned with the rest of the system.