### PR TITLE
Feat: add Nuke packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ lib/*SiteCore*
 lib/Sitecore*
 lib/9.2
 lib/9.3
+
+.nuke/temp/
+artifacts/

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "Rider",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI",
+            "VisualStudio",
+            "VSCode"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "PatchAssemblyInfo": {
+          "type": "boolean",
+          "description": "Patch all assemblyinfo.cs files in the solution before compile"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "SitecoreLibsUrl": {
+          "type": "string"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "CleanupPatchAssemblyInfo",
+              "Compile",
+              "DownloadSitecoreLibs",
+              "Package",
+              "PatchAssemblyInfo",
+              "Restore",
+              "RestoreSitecoreLibs",
+              "UpdateUcommerceNugets"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Clean",
+              "CleanupPatchAssemblyInfo",
+              "Compile",
+              "DownloadSitecoreLibs",
+              "Package",
+              "PatchAssemblyInfo",
+              "Restore",
+              "RestoreSitecoreLibs",
+              "UpdateUcommerceNugets"
+            ]
+          }
+        },
+        "UcommerceNugetSource": {
+          "type": "string",
+          "description": "The directory where the Ucommerce Nuget packages can be found"
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        },
+        "Version": {
+          "type": "string",
+          "description": "The version in semver format"
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "src/Ucommerce.Sitecore.sln"
+}

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,7 @@
+:; set -eo pipefail
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
+:; exit $?
+
+@ECHO OFF
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.PSVersion)"
+
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { Write-Error $_ -ErrorAction Continue; exit 1 }
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+$BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+
+$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
+$DotNetChannel = "Current"
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function ExecSafe([scriptblock] $cmd) {
+    & $cmd
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
+     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $env:DOTNET_EXE = (Get-Command "dotnet").Path
+}
+else {
+    # Download install script
+    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+
+    # If global.json exists, load expected version
+    if (Test-Path $DotNetGlobalFile) {
+        $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
+        if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
+            $DotNetVersion = $DotNetGlobal.sdk.version
+        }
+    }
+
+    # Install by channel or version
+    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    if (!(Test-Path variable:DotNetVersion)) {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+    } else {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+    }
+    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+}
+
+Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+bash --version 2>&1 | head -n 1
+
+set -eo pipefail
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_CHANNEL="Current"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function FirstJsonValue {
+    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
+    export DOTNET_EXE="$(command -v dotnet)"
+else
+    # Download install script
+    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+    mkdir -p "$TEMP_DIRECTORY"
+    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    chmod +x "$DOTNET_INSTALL_FILE"
+
+    # If global.json exists, load expected version
+    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
+        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
+        if [[ "$DOTNET_VERSION" == ""  ]]; then
+            unset DOTNET_VERSION
+        fi
+    fi
+
+    # Install by channel or version
+    DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
+    if [[ -z ${DOTNET_VERSION+x} ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    fi
+    export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+fi
+
+echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/.editorconfig
+++ b/build/.editorconfig
@@ -1,0 +1,11 @@
+[*.cs]
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_require_accessibility_modifiers = never:warning
+
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning

--- a/build/Build.PatchAssemblyInfo.cs
+++ b/build/Build.PatchAssemblyInfo.cs
@@ -1,0 +1,48 @@
+using System;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Tools.Git;
+using Nuke.Common.Utilities;
+
+// These targets take care of patching the assemblyinfo.cs files, and cleaning up again, in the project
+partial class Build
+{
+    [Parameter("Patch all assemblyinfo.cs files in the solution before compile", Name = "PatchAssemblyInfo")]
+    bool ShouldPatchAssemblyInfo;
+    
+    [Parameter("The version in semver format")] 
+    string Version = "0.0.0";
+    
+    string BuildNumber => $"{DateTime.Today:yy}{DateTime.Today.DayOfYear:000}";
+
+    string FullVersion => $"{Version}.{BuildNumber}";
+    Target PatchAssemblyInfo => _ => _
+         .OnlyWhenStatic(() => ShouldPatchAssemblyInfo)
+         .DependentFor(Compile)
+         .Unlisted()
+         .Executes(() =>
+         {
+             var commitSha = GitTasks.GitCurrentCommit();
+             var assemblyInfoFiles = SourceDirectory.GlobFiles("**/AssemblyInfo.cs");
+             foreach (var assemblyInfoFile in assemblyInfoFiles)
+             {
+                 var contents = TextTasks.ReadAllText(assemblyInfoFile);
+
+                 var newContents = contents
+                     .ReplaceRegex("AssemblyVersion\\(.*\\)", _ => $"AssemblyVersion(\"{FullVersion}\")")
+                     .ReplaceRegex("AssemblyFileVersion\\(.*\\)", _ => $"AssemblyFileVersion(\"{FullVersion}\")")
+                     .ReplaceRegex("AssemblyInformationalVersion\\(.*\\)", _ => $"AssemblyInformationalVersion(\"{FullVersion} {commitSha}\")");
+                TextTasks.WriteAllText(assemblyInfoFile, newContents);                 
+             }
+         });
+
+    // ReSharper disable once UnusedMember.Local
+    Target CleanupPatchAssemblyInfo => _ => _
+        .TriggeredBy(PatchAssemblyInfo)
+        .After(Compile)
+        .Unlisted()
+        .Executes(() =>
+        {
+            GitTasks.Git("checkout -- \"**\\AssemblyInfo.cs\"", SourceDirectory);
+        });
+}

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,279 @@
+using System;
+using System.IO;
+using System.Linq;
+using Helpers;
+using Nuke.Common;
+using Nuke.Common.Execution;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.MSBuild;
+using Nuke.Common.Tools.NuGet;
+using Nuke.Common.Utilities.Collections;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.Tools.MSBuild.MSBuildTasks;
+
+[CheckBuildProjectConfigurations]
+partial class Build : NukeBuild
+{
+    /// Support plugins are available for:
+    ///   - JetBrains ReSharper        https://nuke.build/resharper
+    ///   - JetBrains Rider            https://nuke.build/rider
+    ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
+    ///   - Microsoft VSCode           https://nuke.build/vscode
+
+    public static int Main () => Execute<Build>(x => x.Compile);
+
+    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
+    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+    [Solution] readonly Solution Solution;
+
+    AbsolutePath SourceDirectory => RootDirectory / "src";
+    AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+
+    [Parameter("The directory where the Ucommerce Nuget packages can be found")]
+    AbsolutePath UcommerceNugetSource
+    {
+        get => UcommerceNugetSourceField ?? ArtifactsDirectory;
+        set => UcommerceNugetSourceField = value;
+    }
+    AbsolutePath UcommerceNugetSourceField;
+
+    readonly AbsolutePath SitecoreLibsZip = TemporaryDirectory / "sitecore.lib.zip";
+
+    [Parameter] string SitecoreLibsUrl;
+    
+    // ReSharper disable once UnusedMember.Local
+    Target Clean => _ => _
+        .Before(Restore)
+        .Executes(() =>
+        {
+            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(DeleteDirectory);
+            EnsureCleanDirectory(ArtifactsDirectory);
+        });
+    
+    Target Restore => _ => _
+        .Executes(() =>
+        {
+            NuGetTasks.NuGetRestore(settings => settings.SetTargetPath(Solution));
+        });
+
+    // ReSharper disable once UnusedMember.Local
+    Target UpdateUcommerceNugets => _ => _
+        .Description("Updates the Ucommerce packages to the newest version from a directory on the filesystem")
+        .After(Restore)
+        .Before(Compile)
+        .Executes(() =>
+        {
+            UcommerceNugetSource.GlobFiles("*").ForEach(path => Logger.Info(path));
+            NuGetTasks.NuGet($"update {Solution.Path} -Id Ucommerce.Core -Id Ucommerce -Id Ucommerce.Client.WebForms -source {UcommerceNugetSource} -source nuget.org");
+        });
+
+    // ReSharper disable once UnusedMember.Local
+    Target DownloadSitecoreLibs => _ => _
+        .Description("Internal target used by pipelines, see README.md file for how to get sitecore DLLs into libs")
+        .Before(RestoreSitecoreLibs)
+        .Executes(() =>
+        {
+            DeleteFile(SitecoreLibsZip);
+            HttpTasks.HttpDownloadFile(SitecoreLibsUrl, SitecoreLibsZip);
+        });
+    
+    // ReSharper disable once UnusedMember.Local
+    Target RestoreSitecoreLibs => _ => _
+        .Description("Internal target used by pipelines, see README.md file for how to get sitecore DLLs into libs")
+        .Before(Compile)
+        .Executes(() =>
+        {
+            var sitecoreLibsDir = RootDirectory / "lib" / "Sitecore";
+            EnsureCleanDirectory(sitecoreLibsDir);
+            CompressionTasks.UncompressZip(SitecoreLibsZip, sitecoreLibsDir);
+        });
+    
+    Target Compile => _ => _
+        .DependsOn(Restore)
+        .Executes(() =>
+        {
+            MSBuild(s => s
+                .SetTargetPath(Solution)
+                .SetTargets("Rebuild")
+                .SetConfiguration(Configuration)
+                .SetProcessArgumentConfigurator(a => a
+                    .Add("/p:PostBuildEvent=")
+                )
+                .SetNodeReuse(IsLocalBuild));
+        });
+
+    Target Package => _ => _
+        .DependsOn(Compile)
+        .Description("Packages the files as a Sitecore package")
+        .Executes(() =>
+        {
+            var workDir = TemporaryDirectory / "sitecore";
+            EnsureCleanDirectory(workDir);
+            var filesDir = workDir / "files";
+            var installerDir = workDir / "installer";
+            var metadataDir = workDir / "metadata";
+            
+            var shellDir = filesDir / "sitecore modules" / "Shell";
+            var ucommerceDir = shellDir / "Ucommerce";
+            var binDir = filesDir / "bin";
+            
+
+            // ReSharper disable once PossibleNullReferenceException
+            var installerProject = Solution.GetProject("Ucommerce.Sitecore.Installer");
+            var installerProjectDir = installerProject.Directory;
+            var installerPackageDir = installerProjectDir / "package";
+
+            var webProject = Solution.GetProject("Ucommerce.Sitecore.Web");
+           
+            CopyDirectoryRecursively(installerPackageDir / "installer", installerDir);
+            CopyDirectoryRecursively(installerPackageDir / "metadata", metadataDir);
+            //Update the sitecore package info with the version we are building.
+            TextTasks.WriteAllText(metadataDir / "sc_version.txt", FullVersion);
+            TextTasks.WriteAllText(metadataDir / "sc_name.txt", $"Ucommerce {FullVersion}");
+            
+            CopyDirectoryRecursively(installerPackageDir / "Files", filesDir );
+
+            //////////
+            // Bins //
+            //////////
+            
+            installerProject.GetOutputDir(Configuration)
+                .GlobFiles("Ucommerce.Installer.dll", "Ucommerce.Sitecore.Installer.dll")
+                .Append(RootDirectory / "lib" / "XmlTransform"/ "Microsoft.Web.XmlTransform.dll")
+                .ForEach(path => CopyFileToDirectory(path, binDir));
+            
+            // Fake Assemblies for update
+            new [] {"Ucommerce.Admin.dll", "Ucommerce.systemWeb.dll", "Ucommerce.Pipelines.dll"}
+                .ForEach(fileName => File.Create(binDir / fileName));
+            
+            ////////////
+            // Shell  //
+            ////////////
+
+            var packagesDir = SourceDirectory / "packages";
+            // We get the last client package since updating the package will leave the old version still in the folder 
+            var clientPackagePath = packagesDir.GlobDirectories("Ucommerce.Client.WebForms*").Last();
+            CopyDirectoryRecursively(
+                clientPackagePath / "UcommerceFiles", 
+                shellDir, DirectoryExistsPolicy.Merge,
+                excludeDirectory: directoryInfo => 
+                    new [] {"umbraco5", "umbraco6", "umbraco7", "umbraco8", "sitefinity"}.Contains(directoryInfo.Name, StringComparer.CurrentCultureIgnoreCase),
+                excludeFile: fileInfo =>
+                {
+                    return new []
+                               {
+                                   "UCommerce6.js", "baskets.addaddress.sitecore.config.default", "settingsmanager.aspx"
+                               }
+                               .Contains(fileInfo.Name, StringComparer.InvariantCultureIgnoreCase) ||
+                           fileInfo.Name.Contains("umbraco", StringComparison.InvariantCultureIgnoreCase) ||
+                           fileInfo.Name.Contains("sitefinity", StringComparison.InvariantCultureIgnoreCase) ||
+                           fileInfo.Name.Contains("kentico", StringComparison.InvariantCultureIgnoreCase);
+                });
+
+            var webShellDir = webProject.Directory / "Shell"; 
+            webShellDir
+                .GlobFiles(
+                "OrderManager.aspx",
+                "PromotionManager.aspx"
+                )
+                .ForEach(path => CopyFileToDirectory(path, ucommerceDir / "shell"));
+            
+            CopyFile(webShellDir / "Scripts" / "Sitecore.js", ucommerceDir / "shell" / "app" / "constants.js");
+
+            var webProjectsAppsDir = webProject.Directory / "Apps"; 
+            webProjectsAppsDir
+                .GlobDirectories("*")
+                .ForEach(path => CopyDirectoryRecursively(path,  ucommerceDir / "Apps" / webProjectsAppsDir.GetRelativePathTo(path)));
+            
+            CopyFileToDirectory(webProject.Directory / "Configuration" / "Shell.config.default", ucommerceDir / "Configuration");
+
+            CopyDirectoryRecursively(
+                webProject.Directory / "Css", 
+                ucommerceDir / "Css", 
+                DirectoryExistsPolicy.Merge,
+                excludeFile:info => info.Name.Contains(".less"));
+
+            ///////////////////////
+            // Ucommerce Install //
+            ///////////////////////
+            var ucommerceInstallDir = ucommerceDir / "install";
+            
+            CopyDirectoryRecursively(installerProjectDir / "SpeakSerialization", ucommerceInstallDir / "SpeakSerialization");
+            
+            CopyDirectoryRecursively(installerProjectDir / "ConfigurationTransformations", ucommerceInstallDir, DirectoryExistsPolicy.Merge);
+            RenameDirectory(ucommerceInstallDir / "ConfigIncludes", "configinclude");
+            
+            CopyDirectoryRecursively(RootDirectory / "database", ucommerceInstallDir, DirectoryExistsPolicy.Merge);
+            
+            Solution.GetProject("Ucommerce.Sitecore").GetOutputDir(Configuration)
+                .GlobFiles(
+                    "Ucommerce*.dll",
+                    "castle.core.dll",
+                    "castle.windsor.dll",
+                    "clientdependency.core.dll",
+                    "Castle.Facilities.AspNet.SystemWeb.dll",
+                    "csvhelper.dll", 
+                    "epplus.dll", 
+                    "fluentnhibernate.dll", 
+                    "iesi.collections.dll", 
+                    "infralution.licensing.dll", 
+                    "log4net.dll", 
+                    "lucene.net.dll", 
+                    "microsoft.web.xmltransform.dll",
+                    "newtonsoft.json.dll", 
+                    "nhibernate.caches.syscache.dll", 
+                    "nhibernate.dll", 
+                    "Antlr3.Runtime.dll", 
+                    "Remotion.Linq.dll",
+                    "Remotion.Linq.EagerFetching.dll", 
+                    "FluentValidation.dll", 
+                    "Slugify.Core.dll", 
+                    "Dapper.dll", 
+                    "J2N.dll", 
+                    "System.Linq.Dynamic.dll")
+                .Where(path =>
+                {
+                    if (Configuration == Configuration.Debug)
+                    {
+                        return true;
+                    }
+                    var extension = Path.GetExtension(path.ToString()); 
+                    return extension != ".pdb" && extension != ".xml";
+                })
+                .Where(path => !path.ToString().Contains("Ucommerce.Installer.dll"))
+                // ReSharper disable once PossibleNullReferenceException
+                .Append(webProject.Directory / "bin"  / "Ucommerce.Sitecore.Web.dll")
+                .Append(RootDirectory / "lib" / "Lucene.net" / "Lucene.net.dll")
+                .ForEach(path => CopyFileToDirectory(path, ucommerceInstallDir / "binaries", FileExistsPolicy.Overwrite));
+            
+            //////////////////////////
+            // Commerce Connect APP //
+            //////////////////////////
+            CopyDirectoryRecursively(SourceDirectory / "Ucommerce.Sitecore.CommerceConnect" / "Configuration", 
+                ucommerceDir / "Apps" / "sitecore commerce connect.disabled");
+            
+            RenameFile(ucommerceDir / "configuration" / "settings" / "settings.sitecore.config.default", "settings.config.default");
+            
+            CopyDirectoryRecursively(webProject.Directory / "Pipelines", ucommerceDir / "Pipelines", DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
+
+
+            ////////////////////////
+            // Compatibility Apps //
+            ////////////////////////
+            CopyFileToDirectory(
+                Solution.GetProject("Ucommerce.Sitecore92").GetOutputDir(Configuration) / "Ucommerce.Sitecore92.dll", 
+                ucommerceDir / "apps" / "Sitecore92compatibility.disabled" / "bin");
+            CopyFileToDirectory(
+                Solution.GetProject("Ucommerce.Sitecore93").GetOutputDir(Configuration) / "Ucommerce.Sitecore93.dll", 
+                ucommerceDir / "apps" / "Sitecore93compatibility.disabled" / "bin");
+            
+            // The internal package.zip file
+            CompressionTasks.CompressZip(workDir, TemporaryDirectory / "package" / "package.zip", fileMode: FileMode.Create);
+            // The versioned Sitecore package.
+            CompressionTasks.CompressZip(TemporaryDirectory / "package",ArtifactsDirectory / $"Ucommerce-for-Sitecore-{FullVersion}.zip", fileMode: FileMode.Create);
+        });
+
+}

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This file prevents unintended imports of unrelated MSBuild files -->
+  <!-- Uncomment to include parent Directory.Build.props file -->
+  <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />-->
+
+</Project>

--- a/build/Directory.Build.targets
+++ b/build/Directory.Build.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- This file prevents unintended imports of unrelated MSBuild files -->
+  <!-- Uncomment to include parent Directory.Build.targets file -->
+  <!--<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />-->
+
+</Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory>..</NukeScriptDirectory>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>build</ToolCommandName>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nuke.Common" Version="5.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="NuGet.CommandLine" Version="[5.10.0]" />
+  </ItemGroup>
+
+</Project>

--- a/build/_build.csproj.DotSettings
+++ b/build/_build.csproj.DotSettings
@@ -1,0 +1,27 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeapView_002EDelegateAllocation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VariableHidesOuterVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBeMadeStatic_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">0</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">120</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">IF_OWNER_IS_SINGLE_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">WRAP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/build/helpers/ProjectExtensions.cs
+++ b/build/helpers/ProjectExtensions.cs
@@ -1,0 +1,18 @@
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+
+namespace Helpers
+{
+    public static class ProjectExtensions
+    {
+        public static AbsolutePath GetOutputDir(this Project project, Configuration configuration)
+        {
+            return project.Directory / "bin" / configuration;
+        }
+        
+        public static void CopyProjectBinDir(this Project project, AbsolutePath targetDir, Configuration configuration)
+        {
+            FileSystemTasks.CopyDirectoryRecursively(project.GetOutputDir(configuration), targetDir);
+        }
+    }
+}

--- a/src/Ucommerce.Sitecore.sln
+++ b/src/Ucommerce.Sitecore.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ucommerce.Sitecore92", "Uco
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ucommerce.Sitecore93", "Ucommerce.Sitecore93\Ucommerce.Sitecore93.csproj", "{BEC8A6FB-3563-4DB7-A915-90D8BC72F99B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{3DE4A0A6-4D67-4853-A890-68A2D47F2C63}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,6 +31,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3DE4A0A6-4D67-4853-A890-68A2D47F2C63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DE4A0A6-4D67-4853-A890-68A2D47F2C63}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1A45A6DD-D898-48E8-869C-7C72891921A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1A45A6DD-D898-48E8-869C-7C72891921A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1A45A6DD-D898-48E8-869C-7C72891921A8}.Release Pro|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Package can now be done with NUKE for our Ucommerce pipelines.
This build is currently only meant for our own internal use, so OSS devs
are still recommended to use the old PowerShell scripts.

The build can update the Ucommerce nugets from filesystem with the
UpdateUcommerceNugets target. It can also download the sitecore libs
from a URL and copy them to the libs folder.

The Package target packages everything to a Sitecore package.