### PR TITLE
Chore: remove System.Collections.Immutable.dll

### DIFF
--- a/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
+++ b/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Web.Hosting;
 using Sitecore.Install.Framework;
 using Ucommerce.Installer;
@@ -103,7 +104,7 @@ namespace Ucommerce.Sitecore.Installer
             // Enable Sanitization app
             _postInstallationSteps.Add(new MoveDirectory($"{virtualAppsPath}/Sanitization.disabled", $"{virtualAppsPath}/Sanitization", true));
             _postInstallationSteps.Add(new DeleteFile($"{virtualAppsPath}/Sanitization/bin/AngleSharp.dll"));
-            _postInstallationSteps.Add(new DeleteFile($"{virtualAppsPath}/Sanitization/bin/AngleSharp.dll"));
+            _postInstallationSteps.Add(new DeleteFile($"{virtualAppsPath}/Sanitization/bin/HtmlSanitizer.dll"));
 
             //Clean up unused configuration since payment integration has move to apps
             _postInstallationSteps.Add(
@@ -132,6 +133,10 @@ namespace Ucommerce.Sitecore.Installer
 
             // Move sitecore config includes into the right path
             ComposeMoveSitecoreConfigIncludes(sitecoreVersionChecker);
+            
+            // Clean up System.Collections.Immutable.dll in Lucene App since it is no longer used
+            _postInstallationSteps.Add(new DeleteFile($"{virtualAppsPath}/Ucommerce.Search.Lucene/bin/System.Collections.Immutable.dll"));
+            _postInstallationSteps.Add(new DeleteFile($"{virtualAppsPath}/Ucommerce.Search.Lucene.disabled/bin/System.Collections.Immutable.dll"));
         }
 
         private void SearchProviderCleanup(string virtualAppsPath)


### PR DESCRIPTION
The search app no longer uses the System.Collections.Immutable.dll file
so it needs to be removed during install/updates.

Also fixed a small bug where we were not removing HtmlSanitizer.dll from
the Sanitization app.