### PR TITLE
chore: add null-check for current user

### DIFF
--- a/src/Ucommerce.Sitecore/Security/SitecoreUserNameService.cs
+++ b/src/Ucommerce.Sitecore/Security/SitecoreUserNameService.cs
@@ -9,7 +9,7 @@ namespace Ucommerce.Sitecore.Security
         {
             get
             {
-                return AuthenticationManager.GetActiveUser().LocalName;
+                return AuthenticationManager.GetActiveUser()?.LocalName;
             }
         }
     }


### PR DESCRIPTION
[ch-14455]

In a headless world, we don't have `CurrentUser` therefore the code will break,
just a simple guard is added.