### PR TITLE
fix: Add binding redirect for .Unsafe package now shipped with core.

### DIFF
--- a/src/UCommerce.SiteCore.Installer/ConfigurationTransformations/updateAssemblyBinding.config
+++ b/src/UCommerce.SiteCore.Installer/ConfigurationTransformations/updateAssemblyBinding.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" xmlns="urn:schemas-microsoft-com:asm.v1"/>
         <bindingRedirect oldVersion="0.0.0.0-5.2.5.0" newVersion="5.2.0.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
       </dependentAssembly>
+      <dependentAssembly xdt:Transform="InsertIfMissing" xdt:Locator="Condition(asmv1:assemblyIdentity/@name='System.Runtime.CompilerServices.Unsafe')">
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" xmlns="urn:schemas-microsoft-com:asm.v1"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" xmlns="urn:schemas-microsoft-com:asm.v1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/UCommerce.SiteCore.Installer/Steps/MoveUcommerceBinaries.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveUcommerceBinaries.cs
@@ -94,6 +94,11 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 "~/bin/ucommerce/Ucommerce.SqlMultiReaderConnector.dll",
                 "~/bin/Ucommerce.SqlMultiReaderConnector.dll",
                 backupTarget: false));
+            
+            _postInstallationSteps.Add(new MoveFile(
+                "~/bin/ucommerce/System.Runtime.CompilerServices.Unsafe.dll",
+                "~/bin/System.Runtime.CompilerServices.Unsafe.dll",
+                backupTarget: false));
 
             foreach (var postInstallationStep in _postInstallationSteps)
             {

--- a/tools/Deploy/uCommerce.Sitecore.ps1
+++ b/tools/Deploy/uCommerce.Sitecore.ps1
@@ -154,7 +154,7 @@ task CopySitecoreFiles -description "Copy all the sitecore files needs for a dep
 	#binaries
 	&robocopy "$src\Ucommerce.Sitecore\bin\$configuration" "$working_dir\files\sitecore modules\Shell\ucommerce\install\binaries" Ucommerce.* /is /it /e /NFL /NDL
 
-    $dependencies = @("castle.core.dll", "castle.windsor.dll", "clientdependency.core.dll","Castle.Facilities.AspNet.SystemWeb.dll" , "csvhelper.dll", "epplus.dll", "fluentnhibernate.dll", "iesi.collections.dll", "infralution.licensing.dll", "log4net.dll", "lucene.net.dll", "microsoft.web.xmltransform.dll". "newtonsoft.json.dll", "nhibernate.caches.syscache.dll", "nhibernate.dll", "Antlr3.Runtime.dll", "Remotion.Linq.dll","Remotion.Linq.EagerFetching.dll", "FluentValidation.dll", "Slugify.Core.dll", "Dapper.dll", "J2N.dll", "System.Linq.Dynamic.dll")
+    $dependencies = @("castle.core.dll", "castle.windsor.dll", "clientdependency.core.dll","Castle.Facilities.AspNet.SystemWeb.dll" , "csvhelper.dll", "epplus.dll", "fluentnhibernate.dll", "iesi.collections.dll", "infralution.licensing.dll", "log4net.dll", "lucene.net.dll", "microsoft.web.xmltransform.dll". "newtonsoft.json.dll", "nhibernate.caches.syscache.dll", "nhibernate.dll", "Antlr3.Runtime.dll", "Remotion.Linq.dll","Remotion.Linq.EagerFetching.dll", "FluentValidation.dll", "Slugify.Core.dll", "Dapper.dll", "J2N.dll", "System.Linq.Dynamic.dll", "System.Runtime.CompilerServices.Unsafe.dll")
 	CopyFiles "$src\Ucommerce.Sitecore\bin\$configuration" "$working_dir\files\sitecore modules\Shell\ucommerce\install\binaries" $dependencies
 
 	# Commerce Connect app


### PR DESCRIPTION
Additionals;

Sitecore ships with the same dll in the bin folder so we need to move ours out from bin/ucommerce to /bin.