### PR TITLE
Sitecore ignores headless api

### DIFF
--- a/src/UCommerce.SiteCore.Installer/ConfigurationTransformations/ConfigIncludes/Sitecore.uCommerce.IgnoreUrlPrefixes.config
+++ b/src/UCommerce.SiteCore.Installer/ConfigurationTransformations/ConfigIncludes/Sitecore.uCommerce.IgnoreUrlPrefixes.config
@@ -1,0 +1,7 @@
+﻿<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+	<sitecore>
+		<settings>
+			<setting name="IgnoreUrlPrefixes" value="/service|/sitecore/default.aspx|/trace.axd|/webresource.axd|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.DialogHandler.aspx|/sitecore/shell/applications/content manager/telerik.web.ui.dialoghandler.aspx|/sitecore/shell/Controls/Rich Text Editor/Telerik.Web.UI.SpellCheckHandler.axd|/Telerik.Web.UI.WebResource.axd|/sitecore/admin/upgrade/|/layouts/testing|/api/v1" patch:instead="setting[@name='IgnoreUrlPrefixes']"/>
+		</settings>
+	</sitecore>
+</configuration>

--- a/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
+++ b/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
@@ -495,6 +495,11 @@ namespace Ucommerce.Sitecore.Installer
                 "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Log4net.config",
                 "~/App_Config/include/Sitecore.uCommerce.Log4net.config",
                 backupTarget: true));
+
+            _postInstallationSteps.Add(new MoveFile(
+                "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.IgnoreUrlPrefixes.config",
+                "~/App_Config/include/Sitecore.uCommerce.IgnoreUrlPrefixes.config",
+                backupTarget: true));
         }
 
         public void Run(ITaskOutput output, NameValueCollection metaData)

--- a/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
+++ b/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
@@ -281,6 +281,9 @@
     </None>
     <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.Dataproviders.config" />
     <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.Events.config" />
+    <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.IgnoreUrlPrefixes.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.Pipelines.HttpRequestBegin.9.3.config" />
     <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.Pipelines.PreProcessRequest.9.1.config" />
     <None Include="ConfigurationTransformations\ConfigIncludes\Sitecore.uCommerce.WebApiConfiguration.config.disabled">


### PR DESCRIPTION
Setting an IgnoreUrlPrefixes so Sitecore ignores the headless url.