### PR TITLE
refactor: create step for upgrading the search providers

### DIFF
--- a/src/UCommerce.SiteCore.Installer/Steps/UpgradeSearchProviders.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/UpgradeSearchProviders.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Ucommerce.Installer;
+
+namespace Ucommerce.Sitecore.Installer.Steps
+{
+    public class UpgradeSearchProviders : IStep
+    {
+        private readonly DirectoryInfo _sitecoreDirectory;
+        private readonly IInstallerLoggingService _logging;
+        private readonly DirectoryInfo _appsDirectory;
+
+        public UpgradeSearchProviders(DirectoryInfo sitecoreDirectory, IInstallerLoggingService logging)
+        {
+            _sitecoreDirectory = sitecoreDirectory;
+            _logging = logging;
+            _appsDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "shell", "ucommerce", "apps"));
+        }
+
+        public async Task Run()
+        {
+            _logging.Information<UpgradeSearchProviders>("Detecting enabled search provider...");
+            var enabledLuceneAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.Lucene"));
+            var disabledLuceneAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.Lucene.disabled"));
+            var enabledElasticAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.ElasticSearch"));
+
+            if (enabledElasticAppDirectory.Exists)
+            {
+                _logging.Information<UpgradeSearchProviders>("ElasticSearch detected, upgrading...");
+                await new UpgradeAppIfEnabled("Ucommerce.Search.ElasticSearch", _sitecoreDirectory, _logging).Run();
+                _logging.Information<UpgradeSearchProviders>("Lucene app enabled by default, disabling...");
+                await new MoveDirectoryIfTargetExist(enabledLuceneAppDirectory, disabledLuceneAppDirectory, _logging).Run();
+            }
+            else
+            {
+                _logging.Information<UpgradeSearchProviders>("Lucene detected, upgrading...");
+            }
+        }
+    }
+}

--- a/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
+++ b/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Steps\SeperateConfigSectionInNewFile.cs" />
     <Compile Include="Steps\SitecoreWebconfigMerger.cs" />
     <Compile Include="Steps\AggregateStep.cs" />
+    <Compile Include="Steps\UpgradeSearchProviders.cs" />
     <Compile Include="Steps\Transformation.cs" />
     <Compile Include="Steps\UpdateUCommerceAssemblyVersionInDatabase.cs" />
   </ItemGroup>


### PR DESCRIPTION
We have taken the logic that was in the ToggleActiveSearchProviderSteps
method in PostInstallationSteps/InstallStep and moved it to a step in
the installflow.

The logic is supposed to be:

If the ElasticSerach app is enabled we need to upgrade it from the
disabled app directory, and disable the lucene app which is enabled by
default in our package.
On the other hand if ElasticSearch is NOT enabled we do nothing.

sc-18571
