### PR TITLE
fix: web config backup is not named correctly

### DIFF
--- a/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
@@ -24,7 +24,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new InstallDatabaseSitecore(baseDirectory, connectionStringLocator, loggingService),
                 new UpdateUCommerceAssemblyVersionInDatabase(updateService, runtimeVersionChecker, loggingService),
                 new CopyFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName, "web.config")),
-                    new FileInfo(Path.Combine(sitecoreDirectory.FullName, "web.config.{DateTime.Now.Ticks}.backup")),
+                    new FileInfo(Path.Combine(sitecoreDirectory.FullName, $"web.config.{DateTime.Now.Ticks}.backup")),
                     loggingService),
                 new SitecoreWebconfigMerger(sitecoreDirectory, loggingService),
                 new SeperateConfigSectionInNewFile("configuration/sitecore/settings",


### PR DESCRIPTION
The naming of the web config backup should use the value of DateTime.Now.Ticks and not "{DateTime.Now.Ticks}"

sc-18574