### PR TITLE
fix: condition for WebApiConfiguration.config is wrong

### DIFF
--- a/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
@@ -96,7 +96,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
                         "Sitecore.uCommerce.WebApiConfiguration.config.disabled")),
                     new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.WebApiConfiguration.config")),
                     true,
-                    () => versionChecker.IsEqualOrGreaterThan(new Version(8, 2)),
+                    () => versionChecker.IsLowerThan(new Version(8, 2)),
                     _loggingService),
                 new MoveFile(new FileInfo(Path.Combine(
                         configIncludeDirectory.FullName,


### PR DESCRIPTION
A small copy/paste bug had snug in. The condition for copying the
WebApiConfiguration.config file from install to config include was
reversed to Greater than 8.2 instead of lower than.

sc-18604
