### PR TITLE
chore: change basepath

### DIFF
--- a/src/UCommerce.SiteCore.Installer/FileExtensions/DirectoryExtensions.cs
+++ b/src/UCommerce.SiteCore.Installer/FileExtensions/DirectoryExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+
+namespace Ucommerce.Sitecore.Installer.FileExtensions
+{
+    internal static class DirectoryExtensions
+    {
+        internal static DirectoryInfo CombineDirectory(this DirectoryInfo directory, params string[] paths)
+        {
+            var path = Path.Combine(directory.FullName, Path.Combine(paths));
+            return new DirectoryInfo(path);
+        }
+
+        internal static FileInfo CombineFile(this DirectoryInfo directory, params string[] paths)
+        {
+            var path = Path.Combine(directory.FullName, Path.Combine(paths));
+            return new FileInfo(path);
+        }
+    }
+}

--- a/src/UCommerce.SiteCore.Installer/Steps/AddHeadlessToIgnoreUrlPrefixes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/AddHeadlessToIgnoreUrlPrefixes.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.XPath;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -49,7 +50,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
 
         private FileInfo GetSitecoreConfigFilePath()
         {
-            var webConfigFilePath = new FileInfo(Path.Combine(_sitecoreDirectory.FullName, "web.config"));
+            var webConfigFilePath = _sitecoreDirectory.CombineFile("web.config");
             if (!webConfigFilePath.Exists)
             {
                 throw new FileNotFoundException($"Could not find web.config: {webConfigFilePath.FullName}", webConfigFilePath.FullName);
@@ -64,7 +65,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 throw new Exception("Could not locate 'configuration/sitecore' in web.config");
             }
 
-            return new FileInfo(Path.Combine(_sitecoreDirectory.FullName, sitecoreConfig));
+            return _sitecoreDirectory.CombineFile(sitecoreConfig);
         }
     }
 }

--- a/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -14,100 +15,88 @@ namespace Ucommerce.Sitecore.Installer.Steps
         {
             _loggingService = loggingService;
             var configIncludeDirectory =
-                new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "ucommerce", "install", "configInclude"));
-            var appIncludeDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "App_Config", "include"));
+                sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "ucommerce", "install", "configInclude");
+            var appIncludeDirectory = sitecoreDirectory.CombineDirectory("App_Config", "include");
 
             Steps.AddRange(new IStep[]
             {
-                new MoveFile(new FileInfo(Path.Combine(configIncludeDirectory.FullName, "Sitecore.uCommerce.Databases.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Databases.config")),
+                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Databases.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Databases.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(configIncludeDirectory.FullName, "Sitecore.uCommerce.Dataproviders.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Dataproviders.config")),
+                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Dataproviders.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Dataproviders.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(configIncludeDirectory.FullName, "Sitecore.uCommerce.Events.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Events.config")),
+                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Events.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Events.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(configIncludeDirectory.FullName, "Sitecore.uCommerce.Sites.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Sites.config")),
+                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Sites.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Sites.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config")),
-                    new FileInfo(Path.Combine(
-                        appIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config"),
+                    appIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
                     true,
                     _loggingService),
-                new MoveFileIf(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.HttpRequestBegin.9.3.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config")),
+                new MoveFileIf(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.HttpRequestBegin.9.3.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
                     true,
                     () => versionChecker.IsEqualOrGreaterThan(new Version(9, 3)),
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.PreProcessRequest.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.PreProcessRequest.config")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.PreProcessRequest.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.PreProcessRequest.config"),
                     true,
                     _loggingService),
-                new MoveFileIf(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.PreProcessRequest.9.1.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.PreProcessRequest.config")),
+                new MoveFileIf(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.PreProcessRequest.9.1.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.PreProcessRequest.config"),
                     true,
                     () => versionChecker.IsEqualOrGreaterThan(new Version(9, 1)),
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(configIncludeDirectory.FullName, "Sitecore.uCommerce.Settings.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Settings.config")),
+                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Settings.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Settings.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled"),
                     true,
                     _loggingService),
-                new MoveFileIfTargetExist(new FileInfo(Path.Combine(
-                        appIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.ModifyPipelines.config")),
+                new MoveFileIfTargetExist(appIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.ModifyPipelines.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.ModifyPipelines.config.disabled"),
                     true,
                     _loggingService),
-                new MoveFileIf(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.WebApiConfiguration.config.disabled")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.WebApiConfiguration.config")),
+                new MoveFileIf(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.WebApiConfiguration.config.disabled"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.WebApiConfiguration.config"),
                     true,
                     () => versionChecker.IsLowerThan(new Version(8, 2)),
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.initialize.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.initialize.config")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.initialize.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.initialize.config"),
                     true,
                     _loggingService),
-                new MoveFile(new FileInfo(Path.Combine(
-                        configIncludeDirectory.FullName,
-                        "Sitecore.uCommerce.Log4net.config")),
-                    new FileInfo(Path.Combine(appIncludeDirectory.FullName, "Sitecore.uCommerce.Log4net.config")),
+                new MoveFile(configIncludeDirectory.CombineFile(
+                        "Sitecore.uCommerce.Log4net.config"),
+                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Log4net.config"),
                     true,
                     _loggingService),
             });

--- a/src/UCommerce.SiteCore.Installer/Steps/CopyDirectory.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/CopyDirectory.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -39,7 +40,8 @@ namespace Ucommerce.Sitecore.Installer.Steps
 
             foreach (var file in sourceDir.GetFiles())
             {
-                var targetFilePath = Path.Combine(destinationDir.FullName, file.Name);
+                var targetFilePath = destinationDir.CombineFile(file.Name)
+                    .FullName;
                 file.CopyTo(targetFilePath, true);
 
                 var fs = file.GetAccessControl();
@@ -50,8 +52,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
             if (!recursive) return;
             foreach (var subDir in subDirs)
             {
-                var newDestinationDir = Path.Combine(destinationDir.FullName, subDir.Name);
-                CopyDir(subDir, new DirectoryInfo(Path.Combine(destinationDir.FullName, subDir.Name)), true, loggingService);
+                CopyDir(subDir, destinationDir.CombineDirectory(subDir.Name), true, loggingService);
             }
         }
     }

--- a/src/UCommerce.SiteCore.Installer/Steps/DeleteRavenDB.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/DeleteRavenDB.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -12,10 +13,10 @@ namespace Ucommerce.Sitecore.Installer.Steps
             _loggingService = loggingService;
             Steps.AddRange(new IStep[]
             {
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "RavenDB25")), _loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "RavenDB25.disabled")), _loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "RavenDB30")), _loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "RavenDB30.disabled")), _loggingService)
+                new DeleteDirectory(appsPath.CombineDirectory("RavenDB25"), _loggingService),
+                new DeleteDirectory(appsPath.CombineDirectory("RavenDB25.disabled"), _loggingService),
+                new DeleteDirectory(appsPath.CombineDirectory("RavenDB30"), _loggingService),
+                new DeleteDirectory(appsPath.CombineDirectory("RavenDB30.disabled"), _loggingService),
             });
         }
 

--- a/src/UCommerce.SiteCore.Installer/Steps/EnableApp.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/EnableApp.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -15,9 +16,9 @@ namespace Ucommerce.Sitecore.Installer.Steps
         {
             _appName = appName;
             _logging = logging;
-            var appsDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "shell", "ucommerce", "apps"));
-            _disabledDirectory = new DirectoryInfo(Path.Combine(appsDirectory.FullName, $"{appName}.disabled"));
-            _enabledDirectory = new DirectoryInfo(Path.Combine(appsDirectory.FullName, appName));
+            var appsDirectory = sitecoreDirectory.CombineDirectory("sitecore modules", "shell", "ucommerce", "apps");
+            _disabledDirectory = appsDirectory.CombineDirectory($"{appName}.disabled");
+            _enabledDirectory = appsDirectory.CombineDirectory(appName);
         }
 
         public async Task Run()

--- a/src/UCommerce.SiteCore.Installer/Steps/InitializeObjectFactory.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InitializeObjectFactory.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Specialized;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Ucommerce.Installer;
 
 namespace Ucommerce.Sitecore.Installer.Steps

--- a/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseSitecore.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseSitecore.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -11,7 +12,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
         public InstallDatabaseSitecore(DirectoryInfo packageBasePath, InstallationConnectionStringLocator connectionStringLocator, IInstallerLoggingService logging)
         {
             var migrationsDirectory =
-                new DirectoryInfo(Path.Combine(packageBasePath.FullName, "package", "files", "sitecore modules", "Shell", "Ucommerce", "Install"));
+                packageBasePath.CombineDirectory("package", "files", "sitecore modules", "Shell", "Ucommerce", "Install");
             var migrations = new MigrationLoader().GetDatabaseMigrations(migrationsDirectory);
 
             _command = new DbInstallerSitecore(connectionStringLocator, migrations, logging);

--- a/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseUcommerce.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseUcommerce.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -10,8 +11,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
 
         public InstallDatabaseUcommerce(DirectoryInfo packageBasePath, InstallationConnectionStringLocator connectionStringLocator, IInstallerLoggingService logging)
         {
-            var migrationsDirectory =
-                new DirectoryInfo(Path.Combine(packageBasePath.FullName, "package", "files", "sitecore modules", "Shell", "Ucommerce", "Install"));
+            var migrationsDirectory =packageBasePath.CombineDirectory( "package", "files", "sitecore modules", "Shell", "Ucommerce", "Install");
             var migrations = new MigrationLoader().GetDatabaseMigrations(migrationsDirectory);
 
             _command = new DbInstallerCore(connectionStringLocator, migrations, logging);

--- a/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseUcommerce.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallDatabaseUcommerce.cs
@@ -9,9 +9,11 @@ namespace Ucommerce.Sitecore.Installer.Steps
     {
         private readonly DbInstaller _command;
 
-        public InstallDatabaseUcommerce(DirectoryInfo packageBasePath, InstallationConnectionStringLocator connectionStringLocator, IInstallerLoggingService logging)
+        public InstallDatabaseUcommerce(DirectoryInfo packageBasePath,
+            InstallationConnectionStringLocator connectionStringLocator,
+            IInstallerLoggingService logging)
         {
-            var migrationsDirectory =packageBasePath.CombineDirectory( "package", "files", "sitecore modules", "Shell", "Ucommerce", "Install");
+            var migrationsDirectory = packageBasePath.CombineDirectory("package", "files", "sitecore modules", "Shell", "Ucommerce", "Install");
             var migrations = new MigrationLoader().GetDatabaseMigrations(migrationsDirectory);
 
             _command = new DbInstallerCore(connectionStringLocator, migrations, logging);

--- a/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -14,7 +15,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
             RuntimeVersionChecker runtimeVersionChecker,
             IInstallerLoggingService loggingService)
         {
-            var appsPath = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "uCommerce", "Apps"));
+            var appsDirectory = sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "uCommerce", "Apps");
             Steps.AddRange(new IStep[]
             {
                 new SitecorePreRequisitesChecker(connectionStringLocator, loggingService),
@@ -22,62 +23,87 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new InstallDatabaseUcommerce(baseDirectory, connectionStringLocator, loggingService),
                 new InstallDatabaseSitecore(baseDirectory, connectionStringLocator, loggingService),
                 new UpdateUCommerceAssemblyVersionInDatabase(updateService, runtimeVersionChecker, loggingService),
-                new CopyDirectory(new DirectoryInfo(Path.Combine(baseDirectory.FullName, "package", "files")), sitecoreDirectory, true, loggingService),
-                new CopyFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName, "web.config")),
-                    new FileInfo(Path.Combine(sitecoreDirectory.FullName, $"web.config.{DateTime.Now.Ticks}.backup")),
+
+                new CopyDirectory(baseDirectory.CombineDirectory("package", "files"), sitecoreDirectory, true, loggingService),
+
+                new CopyFile(sitecoreDirectory.CombineFile("web.config"),
+                    sitecoreDirectory.CombineFile($"web.config.{DateTime.Now.Ticks}.backup"),
                     loggingService),
+
                 new SitecoreWebconfigMerger(sitecoreDirectory, loggingService),
+
                 new SeperateConfigSectionInNewFile("configuration/sitecore/settings",
-                    new FileInfo(Path.Combine(sitecoreDirectory.FullName, "web.config")),
-                    new FileInfo(Path.Combine(sitecoreDirectory.FullName, "App_Config", "Include", ".Sitecore.Settings.config")),
+                    sitecoreDirectory.CombineFile("web.config"),
+                    sitecoreDirectory.CombineFile("App_Config", "Include", ".Sitecore.Settings.config"),
                     loggingService),
-                new MoveDirectory(new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "shell", "ucommerce", "install", "binaries")),
-                    new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "bin", "uCommerce")),
+
+                new MoveDirectory(sitecoreDirectory.CombineDirectory("sitecore modules", "shell", "ucommerce", "install", "binaries"),
+                    sitecoreDirectory.CombineDirectory("bin", "uCommerce"),
                     overwriteTarget: true,
                     loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName, "bin", "ucommerce", "Ucommerce.Installer.dll")), loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName, "bin", "Ucommerce.Transactions.Payments.dll")), loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "ServiceStack")), loggingService),
-                new DeleteRavenDB(appsPath, loggingService),
-                new MoveDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "ExchangeRateAPICurrencyConversion.disabled")),
-                    new DirectoryInfo(Path.Combine(appsPath.FullName, "ExchangeRateAPICurrencyConversion")),
+
+                new DeleteFile(sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Installer.dll"), loggingService),
+
+                new DeleteFile(sitecoreDirectory.CombineFile("bin", "Ucommerce.Transactions.Payments.dll"), loggingService),
+
+                new DeleteDirectory(appsDirectory.CombineDirectory("ServiceStack"), loggingService),
+                new DeleteRavenDB(appsDirectory, loggingService),
+
+                new MoveDirectory(appsDirectory.CombineDirectory("ExchangeRateAPICurrencyConversion.disabled"),
+                    appsDirectory.CombineDirectory("ExchangeRateAPICurrencyConversion"),
                     true,
                     loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "Catalogs")), loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "Catalogs.disabled")), loggingService),
+
+                new DeleteDirectory(appsDirectory.CombineDirectory("Catalogs"), loggingService),
+
+                new DeleteDirectory(appsDirectory.CombineDirectory("Catalogs.disabled"), loggingService),
+
                 new EnableSitecoreCompatibilityApp(versionChecker, sitecoreDirectory, loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "Widgets", "CatalogSearch")), loggingService),
-                new DeleteDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "Widgets", "CatalogSearch.disabled")), loggingService),
-                new MoveDirectory(new DirectoryInfo(Path.Combine(appsPath.FullName, "Sanitization.disabled")),
-                    new DirectoryInfo(Path.Combine(appsPath.FullName, "Sanitization")),
+
+                new DeleteDirectory(appsDirectory.CombineDirectory("Widgets", "CatalogSearch"), loggingService),
+
+                new DeleteDirectory(appsDirectory.CombineDirectory("Widgets", "CatalogSearch.disabled"), loggingService),
+
+                new MoveDirectory(appsDirectory.CombineDirectory("Sanitization.disabled"),
+                    appsDirectory.CombineDirectory("Sanitization"),
                     true,
                     loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(appsPath.FullName, "Sanitization", "bin", "AngleSharp.dll")), loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(appsPath.FullName, "Sanitization", "bin", "HtmlSanitizer.dll")), loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName, "Sanitization", "bin", "HtmlSanitizer.dll")), loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(sitecoreDirectory.FullName,
-                        "sitecore modules",
+
+                new DeleteFile(appsDirectory.CombineFile("Sanitization", "bin", "AngleSharp.dll"), loggingService),
+
+                new DeleteFile(appsDirectory.CombineFile("Sanitization", "bin", "HtmlSanitizer.dll"), loggingService),
+
+                new DeleteFile(sitecoreDirectory.CombineFile("Sanitization", "bin", "HtmlSanitizer.dll"), loggingService),
+
+                new DeleteFile(sitecoreDirectory.CombineFile("sitecore modules",
                         "shell",
                         "ucommerce",
                         "Configuration",
-                        "Payments.config")),
+                        "Payments.config"),
                     loggingService),
+
                 new MoveUcommerceBinaries(sitecoreDirectory, loggingService),
+
                 new MoveResourceFiles(sitecoreDirectory, connectionStringLocator, loggingService),
+
                 new RenameConfigDefaultFilesToConfigFiles(sitecoreDirectory, loggingService),
-                new MoveDirectoryIfTargetExist(new DirectoryInfo(Path.Combine(appsPath.FullName, "SimpleInventory.disabled")),
-                    new DirectoryInfo(Path.Combine(appsPath.FullName, "SimpleInventory")),
+
+                new MoveDirectoryIfTargetExist(appsDirectory.CombineDirectory("SimpleInventory.disabled"),
+                    appsDirectory.CombineDirectory("SimpleInventory"),
                     loggingService),
-                new MoveDirectoryIfTargetExist(new DirectoryInfo(Path.Combine(appsPath.FullName, "Acquire and Cancel Payments.disabled")),
-                    new DirectoryInfo(Path.Combine(appsPath.FullName, "Acquire and Cancel Payments")),
+
+                new MoveDirectoryIfTargetExist(appsDirectory.CombineDirectory("Acquire and Cancel Payments.disabled"),
+                    appsDirectory.CombineDirectory("Acquire and Cancel Payments"),
                     loggingService),
+
                 new UpgradeSearchProviders(sitecoreDirectory, loggingService),
-                new SearchProviderCleanup(appsPath.FullName, loggingService),
+                new SearchProviderCleanup(appsDirectory, loggingService),
                 new RemoveRenamedPipelines(sitecoreDirectory, loggingService),
                 new ComposeMoveSitecoreConfigIncludes(sitecoreDirectory, versionChecker, loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(appsPath.FullName, "Ucommerce.Search.Lucene", "bin", "System.Collections.Immutable.dll")),
+
+                new DeleteFile(appsDirectory.CombineFile("Ucommerce.Search.Lucene", "bin", "System.Collections.Immutable.dll"),
                     loggingService),
-                new DeleteFile(new FileInfo(Path.Combine(appsPath.FullName, "Ucommerce.Search.Lucene.disabled", "bin", "System.Collections.Immutable.dll")),
+                new DeleteFile(appsDirectory.CombineFile("Ucommerce.Search.Lucene.disabled", "bin", "System.Collections.Immutable.dll"),
                     loggingService),
                 new AddHeadlessToIgnoreUrlPrefixes(sitecoreDirectory, loggingService)
             });

--- a/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/InstallStep.cs
@@ -23,84 +23,58 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new InstallDatabaseUcommerce(baseDirectory, connectionStringLocator, loggingService),
                 new InstallDatabaseSitecore(baseDirectory, connectionStringLocator, loggingService),
                 new UpdateUCommerceAssemblyVersionInDatabase(updateService, runtimeVersionChecker, loggingService),
-
                 new CopyDirectory(baseDirectory.CombineDirectory("package", "files"), sitecoreDirectory, true, loggingService),
-
                 new CopyFile(sitecoreDirectory.CombineFile("web.config"),
                     sitecoreDirectory.CombineFile($"web.config.{DateTime.Now.Ticks}.backup"),
                     loggingService),
-
                 new SitecoreWebconfigMerger(sitecoreDirectory, loggingService),
-
                 new SeperateConfigSectionInNewFile("configuration/sitecore/settings",
                     sitecoreDirectory.CombineFile("web.config"),
                     sitecoreDirectory.CombineFile("App_Config", "Include", ".Sitecore.Settings.config"),
                     loggingService),
-
                 new MoveDirectory(sitecoreDirectory.CombineDirectory("sitecore modules", "shell", "ucommerce", "install", "binaries"),
                     sitecoreDirectory.CombineDirectory("bin", "uCommerce"),
                     overwriteTarget: true,
                     loggingService),
-
                 new DeleteFile(sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Installer.dll"), loggingService),
-
                 new DeleteFile(sitecoreDirectory.CombineFile("bin", "Ucommerce.Transactions.Payments.dll"), loggingService),
-
                 new DeleteDirectory(appsDirectory.CombineDirectory("ServiceStack"), loggingService),
                 new DeleteRavenDB(appsDirectory, loggingService),
-
                 new MoveDirectory(appsDirectory.CombineDirectory("ExchangeRateAPICurrencyConversion.disabled"),
                     appsDirectory.CombineDirectory("ExchangeRateAPICurrencyConversion"),
                     true,
                     loggingService),
-
                 new DeleteDirectory(appsDirectory.CombineDirectory("Catalogs"), loggingService),
-
                 new DeleteDirectory(appsDirectory.CombineDirectory("Catalogs.disabled"), loggingService),
-
                 new EnableSitecoreCompatibilityApp(versionChecker, sitecoreDirectory, loggingService),
-
                 new DeleteDirectory(appsDirectory.CombineDirectory("Widgets", "CatalogSearch"), loggingService),
-
                 new DeleteDirectory(appsDirectory.CombineDirectory("Widgets", "CatalogSearch.disabled"), loggingService),
-
                 new MoveDirectory(appsDirectory.CombineDirectory("Sanitization.disabled"),
                     appsDirectory.CombineDirectory("Sanitization"),
                     true,
                     loggingService),
-
                 new DeleteFile(appsDirectory.CombineFile("Sanitization", "bin", "AngleSharp.dll"), loggingService),
-
                 new DeleteFile(appsDirectory.CombineFile("Sanitization", "bin", "HtmlSanitizer.dll"), loggingService),
-
                 new DeleteFile(sitecoreDirectory.CombineFile("Sanitization", "bin", "HtmlSanitizer.dll"), loggingService),
-
                 new DeleteFile(sitecoreDirectory.CombineFile("sitecore modules",
                         "shell",
                         "ucommerce",
                         "Configuration",
                         "Payments.config"),
                     loggingService),
-
                 new MoveUcommerceBinaries(sitecoreDirectory, loggingService),
-
                 new MoveResourceFiles(sitecoreDirectory, connectionStringLocator, loggingService),
-
                 new RenameConfigDefaultFilesToConfigFiles(sitecoreDirectory, loggingService),
-
                 new MoveDirectoryIfTargetExist(appsDirectory.CombineDirectory("SimpleInventory.disabled"),
                     appsDirectory.CombineDirectory("SimpleInventory"),
                     loggingService),
-
                 new MoveDirectoryIfTargetExist(appsDirectory.CombineDirectory("Acquire and Cancel Payments.disabled"),
                     appsDirectory.CombineDirectory("Acquire and Cancel Payments"),
                     loggingService),
-
                 new UpgradeSearchProviders(sitecoreDirectory, loggingService),
                 new SearchProviderCleanup(appsDirectory, loggingService),
                 new RemoveRenamedPipelines(sitecoreDirectory, loggingService),
                 new ComposeMoveSitecoreConfigIncludes(sitecoreDirectory, versionChecker, loggingService),
-
                 new DeleteFile(appsDirectory.CombineFile("Ucommerce.Search.Lucene", "bin", "System.Collections.Immutable.dll"),
                     loggingService),
                 new DeleteFile(appsDirectory.CombineFile("Ucommerce.Search.Lucene.disabled", "bin", "System.Collections.Immutable.dll"),

--- a/src/UCommerce.SiteCore.Installer/Steps/MoveResourceFiles.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveResourceFiles.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -13,8 +14,8 @@ namespace Ucommerce.Sitecore.Installer.Steps
 
         public MoveResourceFiles(DirectoryInfo sitecoreDirectory, InstallationConnectionStringLocator connectionStringLocator, IInstallerLoggingService logging)
         {
-            SourceDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "bin", "uCommerce", "App_GlobalResources"));
-            TargetDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "App_GlobalResources"));
+            SourceDirectory = sitecoreDirectory.CombineDirectory("bin", "uCommerce", "App_GlobalResources");
+            TargetDirectory = sitecoreDirectory.CombineDirectory("App_GlobalResources");
             _loggingService = logging;
         }
 
@@ -59,8 +60,8 @@ namespace Ucommerce.Sitecore.Installer.Steps
 
             foreach (var file in files)
             {
-                steps.Add(new MoveFile(new FileInfo(Path.Combine(SourceDirectory.FullName, file)),
-                    new FileInfo(Path.Combine(TargetDirectory.FullName, file)),
+                steps.Add(new MoveFile(SourceDirectory.CombineFile(file),
+                    TargetDirectory.CombineFile(file),
                     false,
                     _loggingService));
             }

--- a/src/UCommerce.SiteCore.Installer/Steps/MoveUcommerceBinaries.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveUcommerceBinaries.cs
@@ -2,17 +2,18 @@
 using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
     public class MoveUcommerceBinaries : IStep
     {
         private readonly IInstallerLoggingService _logging;
-        private readonly DirectoryInfo _sitecoreBasePath;
+        private readonly DirectoryInfo _sitecoreDirectory;
 
-        public MoveUcommerceBinaries(DirectoryInfo sitecoreBasePath, IInstallerLoggingService logging)
+        public MoveUcommerceBinaries(DirectoryInfo sitecoreDirectory, IInstallerLoggingService logging)
         {
-            _sitecoreBasePath = sitecoreBasePath;
+            _sitecoreDirectory = sitecoreDirectory;
             _logging = logging;
         }
 
@@ -25,95 +26,94 @@ namespace Ucommerce.Sitecore.Installer.Steps
             // Therefor any older version located in the bin folder needs to be removed.
             //_postInstallationSteps.Add(new DeleteFile("~/bin/Ucommerce.Sitecore.CommerceConnect.dll"));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Infrastructure.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Infrastructure.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Infrastructure.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Infrastructure.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Sitecore.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Sitecore.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Sitecore.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Sitecore.dll"),
                 backupTarget: false,
                 _logging));
 
             // Move the Commerce Connect dependend files to the Commerce Connect app location.
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Sitecore.CommerceConnect.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName,
-                    "sitecore modules",
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Sitecore.CommerceConnect.dll"),
+                _sitecoreDirectory.CombineFile("sitecore modules",
                     "Shell",
                     "uCommerce",
                     "Apps",
                     "Sitecore Connect.disabled",
-                    "Ucommerce.Sitecore.CommerceConnect.dll")),
+                    "Ucommerce.Sitecore.CommerceConnect.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Web.Api.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Web.Api.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Web.Api.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Web.Api.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.SystemHttp.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.SystemHttp.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.SystemHttp.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.SystemHttp.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.SystemWeb.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.SystemWeb.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.SystemWeb.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.SystemWeb.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Web.Shell.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Web.Shell.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Web.Shell.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Web.Shell.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Admin.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Admin.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Admin.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Admin.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Pipelines.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Pipelines.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Pipelines.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Pipelines.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Presentation.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Presentation.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Presentation.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Presentation.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.NHibernate.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.NHibernate.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.NHibernate.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.NHibernate.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Pipelines.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Pipelines.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Pipelines.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Pipelines.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Sitecore.Web.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Sitecore.Web.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Sitecore.Web.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Sitecore.Web.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Api.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Api.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Api.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Api.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.Search.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.Search.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.Search.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.Search.dll"),
                 backupTarget: false,
                 _logging));
 
-            installationSteps.Add(new MoveFile(new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "ucommerce", "Ucommerce.SqlMultiReaderConnector.dll")),
-                new FileInfo(Path.Combine(_sitecoreBasePath.FullName, "bin", "Ucommerce.SqlMultiReaderConnector.dll")),
+            installationSteps.Add(new MoveFile(_sitecoreDirectory.CombineFile("bin", "ucommerce", "Ucommerce.SqlMultiReaderConnector.dll"),
+                _sitecoreDirectory.CombineFile("bin", "Ucommerce.SqlMultiReaderConnector.dll"),
                 backupTarget: false,
                 _logging));
 

--- a/src/UCommerce.SiteCore.Installer/Steps/RemoveRenamedPipelines.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/RemoveRenamedPipelines.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -13,37 +14,37 @@ namespace Ucommerce.Sitecore.Installer.Steps
             var pipelinesPath = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "ucommerce", "Pipelines"));
             Steps.AddRange(new IStep[]
             {
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "Basket.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "Checkout.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteCampaignItem.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteCategory.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteDataType.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteDefinition.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteLanguage.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteProduct.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteProductCatalog.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteProductCatalogGroup.config")),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("Basket.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("Checkout.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteCampaignItem.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteCategory.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteDataType.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteDefinition.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteLanguage.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProduct.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductCatalog.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductCatalogGroup.config"),
                     _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "DeleteProductDefinitionField.config")),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductDefinitionField.config"),
                     _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "Processing.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "ProductReview.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "ProductReview.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "ProductReviewComment.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveCategory.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveDataType.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveDefinition.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveDefinitionField.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveLanguage.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveOrder.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveProduct.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveProductCatalog.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveProductCatalogGroup.config")),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("Processing.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReview.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReview.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReviewComment.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveCategory.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDataType.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDefinition.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDefinitionField.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveLanguage.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveOrder.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProduct.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductCatalog.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductCatalogGroup.config"),
                     _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "SaveProductDefinitionField.config")),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductDefinitionField.config"),
                     _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "ToCancelled.config")), _loggingService),
-                new DeleteFileWithBackup(new FileInfo(Path.Combine(pipelinesPath.FullName, "ToCompletedOrder.config")), _loggingService)
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("ToCancelled.config"), _loggingService),
+                new DeleteFileWithBackup(pipelinesPath.CombineFile("ToCompletedOrder.config"), _loggingService)
             });
         }
 

--- a/src/UCommerce.SiteCore.Installer/Steps/RenameConfigDefaultFilesToConfigFiles.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/RenameConfigDefaultFilesToConfigFiles.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -11,19 +12,16 @@ namespace Ucommerce.Sitecore.Installer.Steps
             IInstallerLoggingService loggingService)
         {
             _loggingService = loggingService;
-
+            var ucommerceDirectory = sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "uCommerce");
             Steps.AddRange(new IStep[]
             {
-                new RenameConfigDefaultFilesToConfigFilesStep(
-                    new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "uCommerce", "Configuration")),
+                new RenameConfigDefaultFilesToConfigFilesStep(ucommerceDirectory.CombineDirectory("Configuration"),
                     false,
                     _loggingService),
-                new RenameConfigDefaultFilesToConfigFilesStep(
-                    new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "uCommerce", "Pipelines")),
+                new RenameConfigDefaultFilesToConfigFilesStep(ucommerceDirectory.CombineDirectory("Pipelines"),
                     false,
                     _loggingService),
-                new RenameConfigDefaultFilesToConfigFilesStep(
-                    new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "uCommerce", "Apps")),
+                new RenameConfigDefaultFilesToConfigFilesStep(ucommerceDirectory.CombineDirectory("Apps"),
                     false,
                     _loggingService)
             });

--- a/src/UCommerce.SiteCore.Installer/Steps/SearchProviderCleanup.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/SearchProviderCleanup.cs
@@ -8,11 +8,11 @@ namespace Ucommerce.Sitecore.Installer.Steps
     {
         private readonly IInstallerLoggingService _loggingService;
 
-        public SearchProviderCleanup(DirectoryInfo appsPath, IInstallerLoggingService loggingService)
+        public SearchProviderCleanup(DirectoryInfo appsDirectory, IInstallerLoggingService loggingService)
         {
             _loggingService = loggingService;
-            var luceneIndexesFolderPath = appsPath.CombineDirectory("Ucommerce.Search.Lucene", "Configuration", "Indexes");
-            var luceneIndexesFolderPathDisabled = appsPath.CombineDirectory("Ucommerce.Search.Lucene.disabled", "Configuration", "Indexes");
+            var luceneIndexesFolderPath = appsDirectory.CombineDirectory("Ucommerce.Search.Lucene", "Configuration", "Indexes");
+            var luceneIndexesFolderPathDisabled = appsDirectory.CombineDirectory("Ucommerce.Search.Lucene.disabled", "Configuration", "Indexes");
             if (Directory.Exists(luceneIndexesFolderPath.FullName))
             {
                 Steps.Add(new DeleteDirectory(luceneIndexesFolderPath, _loggingService));

--- a/src/UCommerce.SiteCore.Installer/Steps/SearchProviderCleanup.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/SearchProviderCleanup.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -7,11 +8,11 @@ namespace Ucommerce.Sitecore.Installer.Steps
     {
         private readonly IInstallerLoggingService _loggingService;
 
-        public SearchProviderCleanup(string appsPath, IInstallerLoggingService loggingService)
+        public SearchProviderCleanup(DirectoryInfo appsPath, IInstallerLoggingService loggingService)
         {
             _loggingService = loggingService;
-            var luceneIndexesFolderPath = new DirectoryInfo(Path.Combine(appsPath, "Ucommerce.Search.Lucene", "Configuration", "Indexes"));
-            var luceneIndexesFolderPathDisabled = new DirectoryInfo(Path.Combine(appsPath, "Ucommerce.Search.Lucene.disabled", "Configuration", "Indexes"));
+            var luceneIndexesFolderPath = appsPath.CombineDirectory("Ucommerce.Search.Lucene", "Configuration", "Indexes");
+            var luceneIndexesFolderPathDisabled = appsPath.CombineDirectory("Ucommerce.Search.Lucene.disabled", "Configuration", "Indexes");
             if (Directory.Exists(luceneIndexesFolderPath.FullName))
             {
                 Steps.Add(new DeleteDirectory(luceneIndexesFolderPath, _loggingService));

--- a/src/UCommerce.SiteCore.Installer/Steps/SitecoreWebconfigMerger.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/SitecoreWebconfigMerger.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -19,22 +20,17 @@ namespace Ucommerce.Sitecore.Installer.Steps
         public async Task Run()
         {
             _loggingService.Information<SitecoreWebconfigMerger>("Merging Sitecore and Ucommerce config files...");
-            var ucommerceInstallPath = Path.Combine("sitecore modules", "Shell", "ucommerce", "install");
-            var mergeConfig = new MergeConfig(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, "web.config")),
+            var ucommerceInstallPath = _sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "ucommerce", "install");
+            var mergeConfig = new MergeConfig(_sitecoreDirectory.CombineFile("web.config"),
                 new List<Transformation>
                 {
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, ucommerceInstallPath, "CleanConfig.config"))),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, ucommerceInstallPath, "uCommerce.config"))),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, ucommerceInstallPath, "uCommerce.IIS7.config")),
-                        isIntegrated: true),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName,
-                        ucommerceInstallPath,
-                        "uCommerce.dependencies.sitecore.config"))),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, ucommerceInstallPath, "sitecore.config"))),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName, ucommerceInstallPath, "ClientDependency.config"))),
-                    new Transformation(new FileInfo(Path.Combine(_sitecoreDirectory.FullName,
-                        ucommerceInstallPath,
-                        "updateAssemblyBinding.config")))
+                    new Transformation(ucommerceInstallPath.CombineFile("CleanConfig.config")),
+                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.config")),
+                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.IIS7.config"), true),
+                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.dependencies.sitecore.config")),
+                    new Transformation(ucommerceInstallPath.CombineFile("sitecore.config")),
+                    new Transformation(ucommerceInstallPath.CombineFile("ClientDependency.config")),
+                    new Transformation(ucommerceInstallPath.CombineFile("updateAssemblyBinding.config")),
                 },
                 _loggingService
             );

--- a/src/UCommerce.SiteCore.Installer/Steps/SitecoreWebconfigMerger.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/SitecoreWebconfigMerger.cs
@@ -20,17 +20,17 @@ namespace Ucommerce.Sitecore.Installer.Steps
         public async Task Run()
         {
             _loggingService.Information<SitecoreWebconfigMerger>("Merging Sitecore and Ucommerce config files...");
-            var ucommerceInstallPath = _sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "ucommerce", "install");
+            var ucommerceInstallDirectory = _sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "ucommerce", "install");
             var mergeConfig = new MergeConfig(_sitecoreDirectory.CombineFile("web.config"),
                 new List<Transformation>
                 {
-                    new Transformation(ucommerceInstallPath.CombineFile("CleanConfig.config")),
-                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.config")),
-                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.IIS7.config"), true),
-                    new Transformation(ucommerceInstallPath.CombineFile("uCommerce.dependencies.sitecore.config")),
-                    new Transformation(ucommerceInstallPath.CombineFile("sitecore.config")),
-                    new Transformation(ucommerceInstallPath.CombineFile("ClientDependency.config")),
-                    new Transformation(ucommerceInstallPath.CombineFile("updateAssemblyBinding.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("CleanConfig.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("uCommerce.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("uCommerce.IIS7.config"), true),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("uCommerce.dependencies.sitecore.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("sitecore.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("ClientDependency.config")),
+                    new Transformation(ucommerceInstallDirectory.CombineFile("updateAssemblyBinding.config")),
                 },
                 _loggingService
             );

--- a/src/UCommerce.SiteCore.Installer/Steps/UpgradeAppIfEnabled.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/UpgradeAppIfEnabled.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
@@ -15,9 +16,9 @@ namespace Ucommerce.Sitecore.Installer.Steps
         {
             _appName = appName;
             _logging = logging;
-            var appsDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "shell", "ucommerce", "apps"));
-            _disabledDirectory = new DirectoryInfo(Path.Combine(appsDirectory.FullName, $"{appName}.disabled"));
-            _enabledDirectory = new DirectoryInfo(Path.Combine(appsDirectory.FullName, appName));
+            var appsDirectory = sitecoreDirectory.CombineDirectory("sitecore modules", "shell", "ucommerce", "apps");
+            _disabledDirectory = appsDirectory.CombineDirectory($"{appName}.disabled");
+            _enabledDirectory = appsDirectory.CombineDirectory(appName);
         }
 
         public async Task Run()

--- a/src/UCommerce.SiteCore.Installer/Steps/UpgradeSearchProviders.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/UpgradeSearchProviders.cs
@@ -1,28 +1,29 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Ucommerce.Installer;
+using Ucommerce.Sitecore.Installer.FileExtensions;
 
 namespace Ucommerce.Sitecore.Installer.Steps
 {
     public class UpgradeSearchProviders : IStep
     {
-        private readonly DirectoryInfo _sitecoreDirectory;
-        private readonly IInstallerLoggingService _logging;
         private readonly DirectoryInfo _appsDirectory;
+        private readonly IInstallerLoggingService _logging;
+        private readonly DirectoryInfo _sitecoreDirectory;
 
         public UpgradeSearchProviders(DirectoryInfo sitecoreDirectory, IInstallerLoggingService logging)
         {
             _sitecoreDirectory = sitecoreDirectory;
             _logging = logging;
-            _appsDirectory = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "shell", "ucommerce", "apps"));
+            _appsDirectory = sitecoreDirectory.CombineDirectory("sitecore modules", "shell", "ucommerce", "apps");
         }
 
         public async Task Run()
         {
             _logging.Information<UpgradeSearchProviders>("Detecting enabled search provider...");
-            var enabledLuceneAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.Lucene"));
-            var disabledLuceneAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.Lucene.disabled"));
-            var enabledElasticAppDirectory = new DirectoryInfo(Path.Combine(_appsDirectory.FullName, "Ucommerce.Search.ElasticSearch"));
+            var enabledLuceneAppDirectory = _appsDirectory.CombineDirectory("Ucommerce.Search.Lucene");
+            var disabledLuceneAppDirectory = _appsDirectory.CombineDirectory("Ucommerce.Search.Lucene.disabled");
+            var enabledElasticAppDirectory = _appsDirectory.CombineDirectory("Ucommerce.Search.ElasticSearch");
 
             if (enabledElasticAppDirectory.Exists)
             {

--- a/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
+++ b/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
@@ -213,6 +213,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DbInstallerSitecore.cs" />
+    <Compile Include="FileExtensions\DirectoryExtensions.cs" />
     <Compile Include="ISitecoreVersionChecker.cs" />
     <Compile Include="MessageTemplateParser.cs" />
     <Compile Include="SitecoreVersionCheckerOffline.cs" />

--- a/src/Ucommerce.Sitecore.Cli/Commands/Upgrade.cs
+++ b/src/Ucommerce.Sitecore.Cli/Commands/Upgrade.cs
@@ -1,17 +1,7 @@
-﻿using System.Threading.Tasks;
-using CliFx.Attributes;
-using CliFx.Infrastructure;
+﻿using CliFx.Attributes;
 
 namespace Ucommerce.Sitecore.Cli.Commands
 {
     [Command("upgrade")]
-    public class Upgrade : Install
-    {
-        public override ValueTask ExecuteAsync(IConsole console)
-        {
-            console.Output.WriteLine("Upgrading..");
-         
-            return default;
-        }
-    }
+    public class Upgrade : Install { }
 }


### PR DESCRIPTION
Added a couple of DirectoryInfo extension methods, these help getting rid of all the "new DirectoryInfo(Path.Combine())" in most of the installation steps.

sc-18587