### PR TITLE
refactor: use a list for renamed pipelines

### DIFF
--- a/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/ComposeMoveSitecoreConfigIncludes.cs
@@ -50,7 +50,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new MoveFileIf(configIncludeDirectory.CombineFile(
                         "Sitecore.uCommerce.Pipelines.HttpRequestBegin.9.3.config"),
                     appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
-                    true,
+                    false,
                     () => versionChecker.IsEqualOrGreaterThan(new Version(9, 3)),
                     _loggingService),
                 new MoveFile(configIncludeDirectory.CombineFile(
@@ -61,7 +61,7 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new MoveFileIf(configIncludeDirectory.CombineFile(
                         "Sitecore.uCommerce.Pipelines.PreProcessRequest.9.1.config"),
                     appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.PreProcessRequest.config"),
-                    true,
+                    false,
                     () => versionChecker.IsEqualOrGreaterThan(new Version(9, 1)),
                     _loggingService),
                 new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Settings.config"),

--- a/src/UCommerce.SiteCore.Installer/Steps/RemoveRenamedPipelines.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/RemoveRenamedPipelines.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using Ucommerce.Installer;
 using Ucommerce.Sitecore.Installer.FileExtensions;
 
@@ -11,41 +12,41 @@ namespace Ucommerce.Sitecore.Installer.Steps
         public RemoveRenamedPipelines(DirectoryInfo sitecoreDirectory, IInstallerLoggingService loggingService)
         {
             _loggingService = loggingService;
-            var pipelinesPath = new DirectoryInfo(Path.Combine(sitecoreDirectory.FullName, "sitecore modules", "Shell", "ucommerce", "Pipelines"));
-            Steps.AddRange(new IStep[]
+            var renamedPipelineConfigs = new[]
             {
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("Basket.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("Checkout.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteCampaignItem.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteCategory.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteDataType.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteDefinition.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteLanguage.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProduct.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductCatalog.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductCatalogGroup.config"),
-                    _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("DeleteProductDefinitionField.config"),
-                    _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("Processing.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReview.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReview.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("ProductReviewComment.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveCategory.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDataType.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDefinition.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveDefinitionField.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveLanguage.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveOrder.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProduct.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductCatalog.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductCatalogGroup.config"),
-                    _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("SaveProductDefinitionField.config"),
-                    _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("ToCancelled.config"), _loggingService),
-                new DeleteFileWithBackup(pipelinesPath.CombineFile("ToCompletedOrder.config"), _loggingService)
-            });
+                "Basket.config",
+                "Checkout.config",
+                "DeleteCampaignItem.config",
+                "DeleteCategory.config",
+                "DeleteDataType.config",
+                "DeleteDefinition.config",
+                "DeleteLanguage.config",
+                "DeleteProduct.config",
+                "DeleteProductCatalog.config",
+                "DeleteProductCatalogGroup.config",
+                "DeleteProductDefinitionField.config",
+                "Processing.config",
+                "ProductReview.config",
+                "ProductReview.config",
+                "ProductReviewComment.config",
+                "SaveCategory.config",
+                "SaveDataType.config",
+                "SaveDefinition.config",
+                "SaveDefinitionField.config",
+                "SaveLanguage.config",
+                "SaveOrder.config",
+                "SaveProduct.config",
+                "SaveProductCatalog.config",
+                "SaveProductCatalogGroup.config",
+                "SaveProductDefinitionField.config",
+                "ToCancelled.config",
+                "ToCompletedOrder.config"
+            };
+            Steps.AddRange(renamedPipelineConfigs.Select(
+                config => new DeleteFileWithBackup(
+                    sitecoreDirectory.CombineDirectory("sitecore modules", "Shell", "ucommerce", "Pipelines").CombineFile(config),
+                    _loggingService))
+            );
         }
 
         protected override void LogStart()


### PR DESCRIPTION
The RemoveRenamedPipelines step was repeatingly creating a
DeleteFileWithBackup object. We now instead project a list of filenames
to DeleteFileWithBackup objects. This should make it much easier in the
future to change, and it is possibly easier to read.
