### PR TITLE
chore: add ConfigIncludes to old steps

### DIFF
--- a/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
+++ b/src/UCommerce.SiteCore.Installer/PostInstallationStep.cs
@@ -35,6 +35,7 @@ namespace Ucommerce.Sitecore.Installer
 
             _postInstallationSteps.Add(new CreateApplicationShortcuts());
             _postInstallationSteps.Add(new CreateSpeakApplicationIfSupported(sitecoreVersionChecker));
+            _postInstallationSteps.Add(new MoveSitecoreConfigIncludes());
         }
 
         public void Run(ITaskOutput output, NameValueCollection metaData)

--- a/src/UCommerce.SiteCore.Installer/Steps/MoveFileWeb.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveFileWeb.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Specialized;
+using System.IO;
+using System.Web.Hosting;
+using Sitecore.Install.Framework;
+using Ucommerce.Installer;
+
+namespace Ucommerce.Sitecore.Installer.Steps
+{
+    public class MoveFileWeb : IPostStep
+    {
+        private readonly bool _backupTarget;
+        private readonly FileMover _command;
+
+        public MoveFileWeb(string sourceVirtualPath, string targetVirtualPath, bool backupTarget)
+        {
+            _backupTarget = backupTarget;
+
+            FileInfo source = new FileInfo(HostingEnvironment.MapPath(sourceVirtualPath)),
+                target = new FileInfo(HostingEnvironment.MapPath(targetVirtualPath));
+
+            _command = new FileMover(source, target);
+        }
+
+        public void Run(ITaskOutput output, NameValueCollection metaData)
+        {
+            _command.Move(_backupTarget, ex => new SitecoreInstallerLoggingService().Error<int>(ex));
+        }
+    }
+}

--- a/src/UCommerce.SiteCore.Installer/Steps/MoveSitecoreConfigIncludes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveSitecoreConfigIncludes.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using Sitecore.Install.Framework;
+
+namespace Ucommerce.Sitecore.Installer.Steps
+{
+    public class MoveSitecoreConfigIncludes : IPostStep
+    {
+        public void Run(ITaskOutput output, NameValueCollection metaData)
+        {
+            var steps = new List<IPostStep>
+            {
+                new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Databases.config",
+                    "~/App_Config/include/Sitecore.uCommerce.Databases.config",
+                    backupTarget: false),
+                new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Dataproviders.config",
+                    "~/App_Config/include/Sitecore.uCommerce.Dataproviders.config",
+                    backupTarget: false),
+                new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.initialize.config",
+                    "~/App_Config/include/Sitecore.uCommerce.initialize.config",
+                    backupTarget: false),
+                new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
+                    "~/App_Config/include/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
+                    backupTarget: false)
+            };
+
+            foreach (var step in steps)
+            {
+                step.Run(output, metaData);
+            }
+        }
+    }
+}

--- a/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
+++ b/src/UCommerce.SiteCore.Installer/Ucommerce.Sitecore.Installer.csproj
@@ -216,6 +216,8 @@
     <Compile Include="SitecoreVersionCheckerOnline.cs" />
     <Compile Include="Steps\AddTitleToCommerceSpeakAppsSection.cs" />
     <Compile Include="Steps\CreateSpeakApplicationIfSupported.cs" />
+    <Compile Include="Steps\MoveFileWeb.cs" />
+    <Compile Include="Steps\MoveSitecoreConfigIncludes.cs" />
     <Compile Include="Steps\RemoveUCommerceApplicationLaunchButton.cs" />
     <Compile Include="PostInstallationStep.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Ucommerce.Sitecore.Install.Steps/ComposeMoveSitecoreConfigIncludes.cs
+++ b/src/Ucommerce.Sitecore.Install.Steps/ComposeMoveSitecoreConfigIncludes.cs
@@ -23,14 +23,6 @@ namespace Ucommerce.Sitecore.Install.Steps
 
             Steps.AddRange(new IStep[]
             {
-                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Databases.config"),
-                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Databases.config"),
-                    true,
-                    _loggingService),
-                new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Dataproviders.config"),
-                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Dataproviders.config"),
-                    true,
-                    _loggingService),
                 new MoveFile(configIncludeDirectory.CombineFile("Sitecore.uCommerce.Events.config"),
                     appIncludeDirectory.CombineFile("Sitecore.uCommerce.Events.config"),
                     true,
@@ -43,11 +35,6 @@ namespace Ucommerce.Sitecore.Install.Steps
                         "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config"),
                     appIncludeDirectory.CombineFile(
                         "Sitecore.uCommerce.Pipelines.getItemPersonalizationVisibility.config"),
-                    true,
-                    _loggingService),
-                new MoveFile(configIncludeDirectory.CombineFile(
-                        "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
-                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"),
                     true,
                     _loggingService),
                 new MoveFileIf(configIncludeDirectory.CombineFile(
@@ -91,11 +78,6 @@ namespace Ucommerce.Sitecore.Install.Steps
                     appIncludeDirectory.CombineFile("Sitecore.uCommerce.WebApiConfiguration.config"),
                     true,
                     () => versionChecker.IsLowerThan(new Version(8, 2)),
-                    _loggingService),
-                new MoveFile(configIncludeDirectory.CombineFile(
-                        "Sitecore.uCommerce.initialize.config"),
-                    appIncludeDirectory.CombineFile("Sitecore.uCommerce.initialize.config"),
-                    true,
                     _loggingService),
                 new MoveFile(configIncludeDirectory.CombineFile(
                         "Sitecore.uCommerce.Log4net.config"),

--- a/src/Ucommerce.Sitecore.Install.Steps/InstallStep.cs
+++ b/src/Ucommerce.Sitecore.Install.Steps/InstallStep.cs
@@ -23,6 +23,10 @@ namespace Ucommerce.Sitecore.Install.Steps
             {
                 new SitecorePreRequisitesChecker(connectionStringLocator, loggingService),
                 new InitializeObjectFactory(loggingService),
+                new BackupFile(sitecoreDirectory.CombineFile("App_Config", "include", "Sitecore.uCommerce.Databases.config"), loggingService),
+                new BackupFile(sitecoreDirectory.CombineFile("App_Config", "include", "Sitecore.uCommerce.Dataproviders.config"), loggingService),
+                new BackupFile(sitecoreDirectory.CombineFile("App_Config", "include", "Sitecore.uCommerce.initialize.config"), loggingService),
+                new BackupFile(sitecoreDirectory.CombineFile("App_Config", "include", "Sitecore.uCommerce.Pipelines.HttpRequestBegin.config"), loggingService),
                 new CopyDirectory(baseDirectory.CombineDirectory("package", "files"), sitecoreDirectory, true, loggingService),
                 new CopyFile(sitecoreDirectory.CombineFile("web.config"),
                     sitecoreDirectory.CombineFile($"web.config.{DateTime.Now.Ticks}.backup"),


### PR DESCRIPTION
added back some old code that replaces sitecore config files with empty ones, used to be able to boot up sitecore when the dlls are not available

sc-18673