### PR TITLE
fix: bug in MoveSitecoreConfigIncludes post installation step

### DIFF
--- a/src/UCommerce.SiteCore.Installer/Steps/MoveSitecoreConfigIncludes.cs
+++ b/src/UCommerce.SiteCore.Installer/Steps/MoveSitecoreConfigIncludes.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Sitecore.Install.Framework;
 
@@ -6,6 +7,13 @@ namespace Ucommerce.Sitecore.Installer.Steps
 {
     public class MoveSitecoreConfigIncludes : IPostStep
     {
+        private readonly SitecoreVersionCheckerOnline _versionChecker;
+
+        public MoveSitecoreConfigIncludes(SitecoreVersionCheckerOnline versionChecker)
+        {
+            _versionChecker = versionChecker;
+        }
+
         public void Run(ITaskOutput output, NameValueCollection metaData)
         {
             var steps = new List<IPostStep>
@@ -21,12 +29,23 @@ namespace Ucommerce.Sitecore.Installer.Steps
                 new MoveFileWeb(
                     "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.initialize.config",
                     "~/App_Config/include/Sitecore.uCommerce.initialize.config",
-                    backupTarget: false),
-                new MoveFileWeb(
-                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
-                    "~/App_Config/include/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
                     backupTarget: false)
             };
+
+            if (_versionChecker.IsEqualOrGreaterThan(new Version(9, 3)))
+            {
+                steps.Add(new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Pipelines.HttpRequestBegin.9.3.config",
+                    "~/App_Config/include/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
+                    backupTarget: false));
+            }
+            else
+            {
+                steps.Add(new MoveFileWeb(
+                    "~/sitecore modules/Shell/ucommerce/install/configInclude/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
+                    "~/App_Config/include/Sitecore.uCommerce.Pipelines.HttpRequestBegin.config",
+                    backupTarget: false));
+            }
 
             foreach (var step in steps)
             {


### PR DESCRIPTION
An if statement was missing, to check the sitecore version and move a config accordingly

sc-18676