### PR TITLE
chore: remove xml and pdb from package

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -333,7 +333,14 @@ partial class Build : NukeBuild
                                         .GetProject("Ucommerce.Sitecore.Cli")
                                         .GetOutputDir(Configuration);
 
-            CopyDirectoryRecursively(cliBinDir, rootDir, DirectoryExistsPolicy.Merge);
+            CopyDirectoryRecursively(
+                cliBinDir,
+                rootDir,
+                DirectoryExistsPolicy.Merge,
+                excludeFile: info =>
+                    info.Name.Contains(".pdb") |
+                    info.Name.Contains(".xml")
+            );
 
             CompressionTasks.CompressZip(
                 rootDir,


### PR DESCRIPTION
We do not want too many files in our package since it just makes it
harder to find the uccli.exe file.

sc-18622
